### PR TITLE
chore: expire server discovery requests

### DIFF
--- a/internal/app/metal-controller-manager/cmd/agent/main.go
+++ b/internal/app/metal-controller-manager/cmd/agent/main.go
@@ -20,16 +20,16 @@ import (
 )
 
 func create(endpoint string, s *smbios.Smbios) error {
-	conn, err := grpc.Dial(endpoint, grpc.WithInsecure(), grpc.WithBlock())
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, endpoint, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
 
 	c := api.NewDiscoveryClient(conn)
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
 
 	uuid, err := s.SystemInformation().UUID()
 	if err != nil {


### PR DESCRIPTION
This PR moves to using a context for the grpc dialer so that if the
management plane is down, the registration request will fail after 30s.
This also updated the timeout to 30s instead of just 1s.

Signed-off-by: Spencer Smith <robertspencersmith@gmail.com>

Will close #22 