### PR TITLE
fix: api-port parameter not being used

### DIFF
--- a/app/sidero-controller-manager/main.go
+++ b/app/sidero-controller-manager/main.go
@@ -45,7 +45,6 @@ import (
 const (
 	defaultMaxConcurrentReconciles = 10
 	debugAddr                      = ":9992"
-	httpPort                       = 8081
 )
 
 var (
@@ -84,7 +83,7 @@ func main() {
 	)
 
 	flag.StringVar(&apiEndpoint, "api-endpoint", "", "The endpoint (hostname or IP address) Sidero can be reached at from the servers.")
-	flag.IntVar(&apiPort, "api-port", httpPort, "The TCP port Sidero components can be reached at from the servers.")
+	flag.IntVar(&apiPort, "api-port", 8081, "The TCP port Sidero components can be reached at from the servers.")
 	flag.StringVar(&metricsAddr, "metrics-bind-addr", ":8081", "The address the metric endpoint binds to.")
 	flag.StringVar(&extraAgentKernelArgs, "extra-agent-kernel-args", "", "A comma delimited list of key-value pairs to be added to the agent environment kernel parameters.")
 	flag.StringVar(&bootFromDiskMethod, "boot-from-disk-method", string(ipxe.BootIPXEExit), "Default method to use to boot server from disk if it hits iPXE endpoint after install.")
@@ -293,7 +292,7 @@ func main() {
 			httpMux.ServeHTTP(w, req)
 		})
 
-		err := http.ListenAndServe(fmt.Sprintf(":%d", httpPort), h2c.NewHandler(grpcHandler, h2s))
+		err := http.ListenAndServe(fmt.Sprintf(":%d", apiPort), h2c.NewHandler(grpcHandler, h2s))
 		if err != nil {
 			setupLog.Error(err, "problem running HTTP server")
 		}


### PR DESCRIPTION
We had two variables there: `httpPort` and `apiPort`, and were reading
command line flags into `apiPort` while used only `httpPort` in the
`ListenAndServe` call.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>