### PR TITLE
feat: allow defining http server and api server ports separately

### DIFF
--- a/app/sidero-controller-manager/config/manager/manager.yaml
+++ b/app/sidero-controller-manager/config/manager/manager.yaml
@@ -49,6 +49,7 @@ spec:
             - --metrics-bind-addr=127.0.0.1:8080
             - --api-endpoint=${SIDERO_CONTROLLER_MANAGER_API_ENDPOINT:=-}
             - --api-port=${SIDERO_CONTROLLER_MANAGER_API_PORT:=8081}
+            - --http-port=${SIDERO_CONTROLLER_MANAGER_CONTAINER_API_PORT:=8081}
             - --extra-agent-kernel-args=${SIDERO_CONTROLLER_MANAGER_EXTRA_AGENT_KERNEL_ARGS:=-}
             - --boot-from-disk-method=${SIDERO_CONTROLLER_MANAGER_BOOT_FROM_DISK_METHOD:=ipxe-exit}
             - --auto-accept-servers=${SIDERO_CONTROLLER_MANAGER_AUTO_ACCEPT_SERVERS:=false}
@@ -65,7 +66,7 @@ spec:
               containerPort: 69
               protocol: UDP
             - name: http
-              containerPort: ${SIDERO_CONTROLLER_MANAGER_API_PORT:=8081}
+              containerPort: ${SIDERO_CONTROLLER_MANAGER_CONTAINER_API_PORT:=8081}
               protocol: TCP
           env:
             - name: API_ENDPOINT

--- a/app/sidero-controller-manager/main.go
+++ b/app/sidero-controller-manager/main.go
@@ -70,6 +70,7 @@ func main() {
 		metricsAddr          string
 		apiEndpoint          string
 		apiPort              int
+		httpPort             int
 		extraAgentKernelArgs string
 		bootFromDiskMethod   string
 		enableLeaderElection bool
@@ -84,6 +85,7 @@ func main() {
 
 	flag.StringVar(&apiEndpoint, "api-endpoint", "", "The endpoint (hostname or IP address) Sidero can be reached at from the servers.")
 	flag.IntVar(&apiPort, "api-port", 8081, "The TCP port Sidero components can be reached at from the servers.")
+	flag.IntVar(&httpPort, "http-port", 8081, "The TCP port Sidero controller manager HTTP server is running.")
 	flag.StringVar(&metricsAddr, "metrics-bind-addr", ":8081", "The address the metric endpoint binds to.")
 	flag.StringVar(&extraAgentKernelArgs, "extra-agent-kernel-args", "", "A comma delimited list of key-value pairs to be added to the agent environment kernel parameters.")
 	flag.StringVar(&bootFromDiskMethod, "boot-from-disk-method", string(ipxe.BootIPXEExit), "Default method to use to boot server from disk if it hits iPXE endpoint after install.")
@@ -292,7 +294,7 @@ func main() {
 			httpMux.ServeHTTP(w, req)
 		})
 
-		err := http.ListenAndServe(fmt.Sprintf(":%d", apiPort), h2c.NewHandler(grpcHandler, h2s))
+		err := http.ListenAndServe(fmt.Sprintf(":%d", httpPort), h2c.NewHandler(grpcHandler, h2s))
 		if err != nil {
 			setupLog.Error(err, "problem running HTTP server")
 		}

--- a/website/content/docs/v0.4/Overview/installation.md
+++ b/website/content/docs/v0.4/Overview/installation.md
@@ -18,6 +18,7 @@ variables or as variables in the `clusterctl` configuration:
 - `SIDERO_CONTROLLER_MANAGER_HOST_NETWORK` (`false`): run `sidero-controller-manager` on host network
 - `SIDERO_CONTROLLER_MANAGER_API_ENDPOINT` (empty): specifies the IP address controller manager can be reached on, defaults to the node IP
 - `SIDERO_CONTROLLER_MANAGER_API_PORT` (8081): specifies the port controller manager can be reached on
+- `SIDERO_CONTROLLER_MANAGER_CONTAINER_API_PORT` (8081): specifies the controller manager internal container port
 - `SIDERO_CONTROLLER_MANAGER_EXTRA_AGENT_KERNEL_ARGS` (empty): specifies additional Linux kernel arguments for the Sidero agent (for example, different console settings)
 - `SIDERO_CONTROLLER_MANAGER_AUTO_ACCEPT_SERVERS` (`false`): automatically accept discovered servers, by default `.spec.accepted` should be changed to `true` to accept the server
 - `SIDERO_CONTROLLER_MANAGER_AUTO_BMC_SETUP` (`true`): automatically attempt to configure the BMC with a `sidero` user that will be used for all IPMI tasks.
@@ -34,3 +35,5 @@ These endpoints could be exposed to the infrastructure using different strategie
 
 - running `sidero-controller-manager` on the host network.
 - using Kubernetes load balancers (e.g. MetalLB), ingress controllers, etc.
+
+> Note: If you want to run `sidero-controller-manager` on the host network using port different from `8081` you should set both `SIDERO_CONTROLLER_MANAGER_API_PORT` and `SIDERO_CONTROLLER_MANAGER_CONTAINER_API_PORT` to the same value.


### PR DESCRIPTION
This should provide flexibility in case if running on `hostNetwork` and
want a different port and still keep compatibility with
`loadbalancer`/`ingress` setups.


Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>