### PR TITLE
chore: upgrade cluster-api version from v0.4.4 to v0.4.7 in getting started guide

### DIFF
--- a/website/content/docs/v0.4/Getting Started/prereq-cli-tools.md
+++ b/website/content/docs/v0.4/Getting Started/prereq-cli-tools.md
@@ -39,7 +39,7 @@ The main article for installing `clusterctl` can be found
 
 ```bash
 sudo curl -Lo /usr/local/bin/clusterctl \
-  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.4/clusterctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64" \
+  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64" \
 sudo chmod +x /usr/local/bin/clusterctl
 ```
 

--- a/website/content/docs/v0.5/Getting Started/prereq-cli-tools.md
+++ b/website/content/docs/v0.5/Getting Started/prereq-cli-tools.md
@@ -39,7 +39,7 @@ The main article for installing `clusterctl` can be found
 
 ```bash
 sudo curl -Lo /usr/local/bin/clusterctl \
-  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.4/clusterctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64" \
+  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64" \
 sudo chmod +x /usr/local/bin/clusterctl
 ```
 


### PR DESCRIPTION
Let me know if there are any other files I should be updating.  This resolves an installer error with v0.4.4