### PR TITLE
chore: use consistent naming for imports

### DIFF
--- a/app/caps-controller-manager/controllers/metalmachine_controller.go
+++ b/app/caps-controller-manager/controllers/metalmachine_controller.go
@@ -35,7 +35,7 @@ import (
 
 	infrav1 "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
 	"github.com/talos-systems/sidero/app/caps-controller-manager/pkg/constants"
-	metalv1alpha1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 )
 
 var ErrNoServersInServerClass = errors.New("no servers available in serverclass")
@@ -265,7 +265,7 @@ func (r *MetalMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 		Complete(r)
 }
 
-func (r *MetalMachineReconciler) fetchServerFromClass(ctx context.Context, logger logr.Logger, classRef *corev1.ObjectReference, metalMachine *infrav1.MetalMachine) (*metalv1alpha1.Server, error) {
+func (r *MetalMachineReconciler) fetchServerFromClass(ctx context.Context, logger logr.Logger, classRef *corev1.ObjectReference, metalMachine *infrav1.MetalMachine) (*metalv1.Server, error) {
 	// First, check if there is already existing serverBinding for this metalmachine
 	var serverBindingList infrav1.ServerBindingList
 
@@ -276,7 +276,7 @@ func (r *MetalMachineReconciler) fetchServerFromClass(ctx context.Context, logge
 	for _, serverBinding := range serverBindingList.Items {
 		if serverBinding.Spec.MetalMachineRef.Namespace == metalMachine.Namespace && serverBinding.Spec.MetalMachineRef.Name == metalMachine.Name {
 			// found existing serverBinding for this metalMachine
-			var server metalv1alpha1.Server
+			var server metalv1.Server
 
 			if err := r.Get(ctx, types.NamespacedName{Namespace: serverBinding.Namespace, Name: serverBinding.Name}, &server); err != nil {
 				return nil, err
@@ -302,7 +302,7 @@ func (r *MetalMachineReconciler) fetchServerFromClass(ctx context.Context, logge
 	// NB: we added this loop to double check that an available server isn't "in use" because
 	//     we saw raciness between server selection and it being removed from the ServersAvailable list.
 	for _, availServer := range serverClassResource.Status.ServersAvailable {
-		serverObj := &metalv1alpha1.Server{}
+		serverObj := &metalv1.Server{}
 
 		namespacedName := types.NamespacedName{
 			Namespace: "",
@@ -408,7 +408,7 @@ func (r *MetalMachineReconciler) patchProviderID(ctx context.Context, cluster *c
 }
 
 // createServerBinding updates a server to mark it as "in use" via ServerBinding resource.
-func (r *MetalMachineReconciler) createServerBinding(ctx context.Context, serverClass *metalv1alpha1.ServerClass, serverObj *metalv1alpha1.Server, metalMachine *infrav1.MetalMachine) error {
+func (r *MetalMachineReconciler) createServerBinding(ctx context.Context, serverClass *metalv1.ServerClass, serverObj *metalv1.Server, metalMachine *infrav1.MetalMachine) error {
 	serverRef, err := reference.GetReference(r.Scheme, serverObj)
 	if err != nil {
 		return err
@@ -445,8 +445,8 @@ func (r *MetalMachineReconciler) createServerBinding(ctx context.Context, server
 	return err
 }
 
-func (r *MetalMachineReconciler) fetchServerClass(ctx context.Context, classRef *corev1.ObjectReference) (*metalv1alpha1.ServerClass, error) {
-	serverClassResource := &metalv1alpha1.ServerClass{}
+func (r *MetalMachineReconciler) fetchServerClass(ctx context.Context, classRef *corev1.ObjectReference) (*metalv1.ServerClass, error) {
+	serverClassResource := &metalv1.ServerClass{}
 
 	namespacedName := types.NamespacedName{
 		Namespace: classRef.Namespace,

--- a/app/caps-controller-manager/controllers/serverbinding_controller.go
+++ b/app/caps-controller-manager/controllers/serverbinding_controller.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	infrav1 "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
-	metalv1alpha1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 )
 
 // ServerBindingReconciler reconciles a ServerBinding object.
@@ -75,7 +75,7 @@ func (r *ServerBindingReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}()
 
-	var server metalv1alpha1.Server
+	var server metalv1.Server
 
 	err = r.Get(ctx, req.NamespacedName, &server)
 	if err != nil {
@@ -190,7 +190,7 @@ func (r *ServerBindingReconciler) reconcileTransition(ctx context.Context, logge
 		return ctrl.Result{}, nil
 	}
 
-	var server metalv1alpha1.Server
+	var server metalv1.Server
 
 	if err = r.Get(ctx, req.NamespacedName, &server); err != nil {
 		if apierrors.IsNotFound(err) {

--- a/app/sidero-controller-manager/cmd/agent/main.go
+++ b/app/sidero-controller-manager/cmd/agent/main.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/talos-systems/go-blockdevice/blockdevice"
 	"github.com/talos-systems/go-blockdevice/blockdevice/util/disk"
-	debug "github.com/talos-systems/go-debug"
-	kmsg "github.com/talos-systems/go-kmsg"
+	"github.com/talos-systems/go-debug"
+	"github.com/talos-systems/go-kmsg"
 	"github.com/talos-systems/go-procfs/procfs"
 	"github.com/talos-systems/go-retry/retry"
 	"github.com/talos-systems/go-smbios/smbios"
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/api"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/power/ipmi"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/pkg/constants"
@@ -404,7 +404,7 @@ func attemptBMCIP(ctx context.Context, client api.AgentClient, s *smbios.SMBIOS)
 	bmcInfo := &api.BMCInfo{}
 
 	// Create "open" client
-	bmcSpec := v1alpha1.BMC{
+	bmcSpec := metalv1.BMC{
 		Interface: "open",
 	}
 
@@ -466,7 +466,7 @@ func attemptBMCUserSetup(ctx context.Context, client api.AgentClient, s *smbios.
 	bmcInfo := &api.BMCInfo{}
 
 	// Create "open" client
-	bmcSpec := v1alpha1.BMC{
+	bmcSpec := metalv1.BMC{
 		Interface: "open",
 	}
 

--- a/app/sidero-controller-manager/controllers/suite_test.go
+++ b/app/sidero-controller-manager/controllers/suite_test.go
@@ -18,7 +18,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	metalv1alpha1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -54,10 +54,10 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cfg).ToNot(BeNil())
 
-	err = metalv1alpha1.AddToScheme(scheme.Scheme)
+	err = metalv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = metalv1alpha1.AddToScheme(scheme.Scheme)
+	err = metalv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/app/sidero-controller-manager/internal/power/api/api.go
+++ b/app/sidero-controller-manager/internal/power/api/api.go
@@ -14,7 +14,7 @@ import (
 	"net/http"
 	"time"
 
-	metalv1alpha1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/power/metal"
 )
 
@@ -24,7 +24,7 @@ type Client struct {
 }
 
 // NewClient returns new API client to manage metal machine.
-func NewClient(spec metalv1alpha1.ManagementAPI) (*Client, error) {
+func NewClient(spec metalv1.ManagementAPI) (*Client, error) {
 	return &Client{
 		endpoint: spec.Endpoint,
 	}, nil

--- a/app/sidero-controller-manager/internal/power/factory.go
+++ b/app/sidero-controller-manager/internal/power/factory.go
@@ -10,7 +10,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/power/api"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/power/ipmi"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/power/metal"
@@ -18,7 +18,7 @@ import (
 )
 
 // NewManagementClient builds ManagementClient from the server spec.
-func NewManagementClient(ctx context.Context, client client.Client, spec *v1alpha1.ServerSpec) (metal.ManagementClient, error) {
+func NewManagementClient(ctx context.Context, client client.Client, spec *metalv1.ServerSpec) (metal.ManagementClient, error) {
 	switch {
 	case spec.BMC != nil:
 		var err error

--- a/app/sidero-controller-manager/internal/power/ipmi/ipmi.go
+++ b/app/sidero-controller-manager/internal/power/ipmi/ipmi.go
@@ -9,7 +9,7 @@ import (
 
 	goipmi "github.com/pensando/goipmi"
 
-	metalv1alpha1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/power/metal"
 )
 
@@ -23,7 +23,7 @@ type Client struct {
 }
 
 // NewClient creates an ipmi client to use.
-func NewClient(bmcInfo metalv1alpha1.BMC) (*Client, error) {
+func NewClient(bmcInfo metalv1.BMC) (*Client, error) {
 	conn := &goipmi.Connection{
 		Hostname:  bmcInfo.Endpoint,
 		Port:      int(bmcInfo.Port),

--- a/app/sidero-controller-manager/main.go
+++ b/app/sidero-controller-manager/main.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	infrav1 "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
+	infrav1alpha3 "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
 	metalv1alpha1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/controllers"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/ipxe"
@@ -64,7 +64,7 @@ func init() {
 	_ = capi.AddToScheme(scheme)
 
 	_ = metalv1alpha1.AddToScheme(scheme)
-	_ = infrav1.AddToScheme(scheme)
+	_ = infrav1alpha3.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -13,8 +13,8 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	caps "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
-	scm "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	infrav1 "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 )
 
 // NewClient is responsible for creating a controller-runtime k8s client with all schemas.
@@ -48,11 +48,11 @@ func NewClient(kubeconfig *string) (client.Client, error) {
 		return nil, err
 	}
 
-	if err = caps.AddToScheme(scheme); err != nil {
+	if err = infrav1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 
-	if err = scm.AddToScheme(scheme); err != nil {
+	if err = metalv1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 

--- a/sfyra/pkg/capi/cluster.go
+++ b/sfyra/pkg/capi/cluster.go
@@ -27,8 +27,8 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	sidero "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
-	metal "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	infrav1 "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 )
 
 // Cluster attaches to the provisioned CAPI cluster and provides talos.Cluster.
@@ -100,7 +100,7 @@ func NewCluster(ctx context.Context, metalClient runtimeclient.Reader, clusterNa
 				continue
 			}
 
-			var metalMachine sidero.MetalMachine
+			var metalMachine infrav1.MetalMachine
 
 			if err = metalClient.Get(ctx,
 				types.NamespacedName{Namespace: machine.Spec.InfrastructureRef.Namespace, Name: machine.Spec.InfrastructureRef.Name},
@@ -116,7 +116,7 @@ func NewCluster(ctx context.Context, metalClient runtimeclient.Reader, clusterNa
 				continue
 			}
 
-			var server metal.Server
+			var server metalv1.Server
 
 			if err := metalClient.Get(ctx, types.NamespacedName{Namespace: metalMachine.Spec.ServerRef.Namespace, Name: metalMachine.Spec.ServerRef.Name}, &server); err != nil {
 				return nil, err

--- a/sfyra/pkg/capi/metalclient.go
+++ b/sfyra/pkg/capi/metalclient.go
@@ -12,8 +12,8 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	sidero "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
-	metal "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	infrav1 "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 )
 
 // GetMetalClient builds k8s client with schemes required to access all the CAPI/Sidero/Talos components.
@@ -32,11 +32,11 @@ func GetMetalClient(config *rest.Config) (runtimeclient.Client, error) {
 		return nil, err
 	}
 
-	if err := sidero.AddToScheme(scheme); err != nil {
+	if err := infrav1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 
-	if err := metal.AddToScheme(scheme); err != nil {
+	if err := metalv1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 

--- a/sfyra/pkg/loadbalancer/loadbalancer.go
+++ b/sfyra/pkg/loadbalancer/loadbalancer.go
@@ -25,8 +25,8 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	sidero "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
-	metal "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	infrav1 "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 )
 
 // ControlPlane implements dynamic loadbalancer for the control plane.
@@ -153,13 +153,13 @@ func (cp *ControlPlane) reconcile() error {
 	var upstreams []string
 
 	for _, machine := range machines.Items {
-		var metalMachine sidero.MetalMachine
+		var metalMachine infrav1.MetalMachine
 
 		if err := cp.client.Get(cp.ctx, types.NamespacedName{Namespace: machine.Spec.InfrastructureRef.Namespace, Name: machine.Spec.InfrastructureRef.Name}, &metalMachine); err != nil {
 			continue
 		}
 
-		var server metal.Server
+		var server metalv1.Server
 
 		if metalMachine.Spec.ServerRef == nil {
 			continue

--- a/sfyra/pkg/tests/compatibility.go
+++ b/sfyra/pkg/tests/compatibility.go
@@ -23,7 +23,7 @@ import (
 	"github.com/talos-systems/go-retry/retry"
 	"github.com/talos-systems/talos/pkg/machinery/kernel"
 
-	"github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 	"github.com/talos-systems/sidero/sfyra/pkg/capi"
 	"github.com/talos-systems/sidero/sfyra/pkg/constants"
 	"github.com/talos-systems/sidero/sfyra/pkg/talos"
@@ -42,7 +42,7 @@ func TestCompatibilityCluster(ctx context.Context, metalClient client.Client, cl
 			t.Skip("--prev-talos-release is not set, skipped compatibility check")
 		}
 
-		var environment v1alpha1.Environment
+		var environment metalv1.Environment
 
 		envName := fmt.Sprintf("talos-%s", strings.ReplaceAll(talosRelease, ".", "-"))
 
@@ -82,9 +82,9 @@ func TestCompatibilityCluster(ctx context.Context, metalClient client.Client, cl
 		}))
 
 		serverClassName := envName
-		classSpec := v1alpha1.ServerClassSpec{
-			Qualifiers: v1alpha1.Qualifiers{
-				CPU: []v1alpha1.CPUInformation{
+		classSpec := metalv1.ServerClassSpec{
+			Qualifiers: metalv1.Qualifiers{
+				CPU: []metalv1.CPUInformation{
 					{
 						Manufacturer: "QEMU",
 					},

--- a/sfyra/pkg/tests/environment.go
+++ b/sfyra/pkg/tests/environment.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 	"github.com/talos-systems/sidero/sfyra/pkg/constants"
 	"github.com/talos-systems/sidero/sfyra/pkg/talos"
 )
@@ -28,8 +28,8 @@ const environmentName = "sfyra"
 // TestEnvironmentDefault verifies environment "default".
 func TestEnvironmentDefault(ctx context.Context, metalClient client.Client, cluster talos.Cluster, kernelURL, initrdURL string) TestFunc {
 	return func(t *testing.T) {
-		var environment v1alpha1.Environment
-		err := metalClient.Get(ctx, types.NamespacedName{Name: v1alpha1.EnvironmentDefault}, &environment)
+		var environment metalv1.Environment
+		err := metalClient.Get(ctx, types.NamespacedName{Name: metalv1.EnvironmentDefault}, &environment)
 		require.NoError(t, err)
 		assert.True(t, environment.IsReady())
 
@@ -37,9 +37,9 @@ func TestEnvironmentDefault(ctx context.Context, metalClient client.Client, clus
 		err = metalClient.Delete(ctx, &environment)
 		require.NoError(t, err)
 
-		environment = v1alpha1.Environment{}
+		environment = metalv1.Environment{}
 		err = retry.Constant(60 * time.Second).Retry(func() error {
-			if err := metalClient.Get(ctx, types.NamespacedName{Name: v1alpha1.EnvironmentDefault}, &environment); err != nil {
+			if err := metalClient.Get(ctx, types.NamespacedName{Name: metalv1.EnvironmentDefault}, &environment); err != nil {
 				if apierrors.IsNotFound(err) {
 					return retry.ExpectedError(err)
 				}
@@ -60,7 +60,7 @@ func TestEnvironmentDefault(ctx context.Context, metalClient client.Client, clus
 // TestEnvironmentCreate verifies environment creation.
 func TestEnvironmentCreate(ctx context.Context, metalClient client.Client, cluster talos.Cluster, kernelURL, initrdURL string) TestFunc {
 	return func(t *testing.T) {
-		var environment v1alpha1.Environment
+		var environment metalv1.Environment
 
 		if err := metalClient.Get(ctx, types.NamespacedName{Name: environmentName}, &environment); err != nil {
 			if !apierrors.IsNotFound(err) {

--- a/sfyra/pkg/tests/match.go
+++ b/sfyra/pkg/tests/match.go
@@ -13,7 +13,7 @@ import (
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	metal "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 )
 
 // TestMatchServersMetalMachines verifies that number of metal machines and servers match.
@@ -23,7 +23,7 @@ func TestMatchServersMetalMachines(ctx context.Context, metalClient client.Clien
 
 		require.NoError(t, metalClient.List(ctx, &machines))
 
-		var servers metal.ServerList
+		var servers metalv1.ServerList
 
 		require.NoError(t, metalClient.List(ctx, &servers))
 

--- a/sfyra/pkg/tests/reconcile.go
+++ b/sfyra/pkg/tests/reconcile.go
@@ -19,8 +19,8 @@ import (
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	sidero "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
-	metal "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	infrav1 "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 )
 
 // TestMachineDeploymentReconcile verifies that machine deployment can reconcile delete machines.
@@ -95,7 +95,7 @@ func TestMachineDeploymentReconcile(ctx context.Context, metalClient client.Clie
 // TestServerBindingReconcile verifies that server binding controller can reconcile missing ServerBindings.
 func TestServerBindingReconcile(ctx context.Context, metalClient client.Client) TestFunc {
 	return func(t *testing.T) {
-		var serverBindingList sidero.ServerBindingList
+		var serverBindingList infrav1.ServerBindingList
 
 		require.NoError(t, metalClient.List(ctx, &serverBindingList))
 
@@ -112,7 +112,7 @@ func TestServerBindingReconcile(ctx context.Context, metalClient client.Client) 
 		start := time.Now()
 
 		for time.Since(start) < time.Minute {
-			var server metal.Server
+			var server metalv1.Server
 
 			require.NoError(t, metalClient.Get(ctx, types.NamespacedName{Name: serverBindingToDelete.Name}, &server))
 
@@ -120,7 +120,7 @@ func TestServerBindingReconcile(ctx context.Context, metalClient client.Client) 
 		}
 
 		// server binding should have been re-created
-		var serverBinding sidero.ServerBinding
+		var serverBinding infrav1.ServerBinding
 
 		require.NoError(t, metalClient.Get(ctx, types.NamespacedName{Name: serverBindingToDelete.Name}, &serverBinding))
 
@@ -141,7 +141,7 @@ func TestServerBindingReconcile(ctx context.Context, metalClient client.Client) 
 // ref wasn't set.
 func TestMetalMachineServerRefReconcile(ctx context.Context, metalClient client.Client) TestFunc {
 	return func(t *testing.T) {
-		var serverBindingList sidero.ServerBindingList
+		var serverBindingList infrav1.ServerBindingList
 
 		require.NoError(t, metalClient.List(ctx, &serverBindingList))
 
@@ -153,7 +153,7 @@ func TestMetalMachineServerRefReconcile(ctx context.Context, metalClient client.
 		serverBinding := serverBindingList.Items[0]
 
 		// get matching metalmachine
-		var metalMachine sidero.MetalMachine
+		var metalMachine infrav1.MetalMachine
 
 		require.NoError(t, metalClient.Get(ctx, types.NamespacedName{Namespace: serverBinding.Spec.MetalMachineRef.Namespace, Name: serverBinding.Spec.MetalMachineRef.Name}, &metalMachine))
 

--- a/sfyra/pkg/tests/reset.go
+++ b/sfyra/pkg/tests/reset.go
@@ -15,14 +15,14 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	metal "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
-	sidero "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
+	infrav1 "github.com/talos-systems/sidero/app/caps-controller-manager/api/v1alpha3"
+	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha1"
 )
 
 // TestServerReset verifies that all the servers got reset.
 func TestServerReset(ctx context.Context, metalClient client.Client) TestFunc {
 	return func(t *testing.T) {
-		var machines metal.MetalMachineList
+		var machines infrav1.MetalMachineList
 
 		labelSelector, err := labels.Parse("cluster.x-k8s.io/cluster-name=management-cluster,cluster.x-k8s.io/deployment-name=management-cluster-workers")
 		require.NoError(t, err)
@@ -44,7 +44,7 @@ func TestServerReset(ctx context.Context, metalClient client.Client) TestFunc {
 		require.NoError(t, err)
 
 		err = retry.Constant(5*time.Minute, retry.WithUnits(10*time.Second)).Retry(func() error {
-			var servers sidero.ServerList
+			var servers metalv1.ServerList
 
 			err = metalClient.List(ctx, &servers)
 			if err != nil {


### PR DESCRIPTION
Imports should be consistently named so future changes are more readable and easier to understand.

Signed-off-by: Gerard de Leeuw <gdeleeuw@leeuwit.nl>