### PR TITLE
feat: allow running sidero without siderolink, changes after org rename

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -5,7 +5,7 @@ policies:
       gpg:
         required: true
         identity:
-          gitHubOrganization: talos-systems
+          gitHubOrganization: siderolabs
       spellcheck:
         locale: US
       maximumOfOneCommit: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,25 +7,25 @@ ARG PKGS
 
 # Resolve package images using ${PKGS} to be used later in COPY --from=.
 
-FROM ghcr.io/talos-systems/ca-certificates:${PKGS} AS pkg-ca-certificates
-FROM ghcr.io/talos-systems/fhs:${PKGS} AS pkg-fhs
-FROM ghcr.io/talos-systems/ipmitool:${PKGS} AS pkg-ipmitool
-FROM --platform=amd64 ghcr.io/talos-systems/ipmitool:${PKGS} AS pkg-ipmitool-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/ipmitool:${PKGS} AS pkg-ipmitool-arm64
-FROM ghcr.io/talos-systems/libressl:${PKGS} AS pkg-libressl
-FROM --platform=amd64 ghcr.io/talos-systems/libressl:${PKGS} AS pkg-libressl-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/libressl:${PKGS} AS pkg-libressl-arm64
-FROM --platform=amd64 ghcr.io/talos-systems/linux-firmware:${PKGS} AS pkg-linux-firmware-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/linux-firmware:${PKGS} AS pkg-linux-firmware-arm64
-FROM ghcr.io/talos-systems/musl:${PKGS} AS pkg-musl
-FROM --platform=amd64 ghcr.io/talos-systems/musl:${PKGS} AS pkg-musl-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/musl:${PKGS} AS pkg-musl-arm64
-FROM --platform=amd64 ghcr.io/talos-systems/kernel:${PKGS} AS pkg-kernel-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/kernel:${PKGS} AS pkg-kernel-arm64
-FROM ghcr.io/talos-systems/liblzma:${PKGS} AS pkg-liblzma
-FROM ghcr.io/talos-systems/ipxe:${PKGS} AS pkg-ipxe
-FROM --platform=amd64 ghcr.io/talos-systems/ipxe:${PKGS} AS pkg-ipxe-amd64
-FROM --platform=arm64 ghcr.io/talos-systems/ipxe:${PKGS} AS pkg-ipxe-arm64
+FROM ghcr.io/siderolabs/ca-certificates:${PKGS} AS pkg-ca-certificates
+FROM ghcr.io/siderolabs/fhs:${PKGS} AS pkg-fhs
+FROM ghcr.io/siderolabs/ipmitool:${PKGS} AS pkg-ipmitool
+FROM --platform=amd64 ghcr.io/siderolabs/ipmitool:${PKGS} AS pkg-ipmitool-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/ipmitool:${PKGS} AS pkg-ipmitool-arm64
+FROM ghcr.io/siderolabs/libressl:${PKGS} AS pkg-libressl
+FROM --platform=amd64 ghcr.io/siderolabs/libressl:${PKGS} AS pkg-libressl-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/libressl:${PKGS} AS pkg-libressl-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/linux-firmware:${PKGS} AS pkg-linux-firmware-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/linux-firmware:${PKGS} AS pkg-linux-firmware-arm64
+FROM ghcr.io/siderolabs/musl:${PKGS} AS pkg-musl
+FROM --platform=amd64 ghcr.io/siderolabs/musl:${PKGS} AS pkg-musl-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/musl:${PKGS} AS pkg-musl-arm64
+FROM --platform=amd64 ghcr.io/siderolabs/kernel:${PKGS} AS pkg-kernel-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/kernel:${PKGS} AS pkg-kernel-arm64
+FROM ghcr.io/siderolabs/liblzma:${PKGS} AS pkg-liblzma
+FROM ghcr.io/siderolabs/ipxe:${PKGS} AS pkg-ipxe
+FROM --platform=amd64 ghcr.io/siderolabs/ipxe:${PKGS} AS pkg-ipxe-amd64
+FROM --platform=arm64 ghcr.io/siderolabs/ipxe:${PKGS} AS pkg-ipxe-arm64
 
 # The base target provides the base for running various tasks against the source
 # code
@@ -117,7 +117,7 @@ ARG GO_LDFLAGS
 RUN --mount=type=cache,target=/.cache GOOS=linux GOARCH=${TARGETARCH} go build ${GO_BUILDFLAGS} -ldflags "${GO_LDFLAGS}" -o /manager ./app/caps-controller-manager
 RUN chmod +x /manager
 
-## TODO(rsmitty): make bmc pkg and move to talos-systems image
+## TODO(rsmitty): make bmc pkg and move to siderolabs image
 FROM scratch AS caps-controller-manager
 COPY --from=pkg-ca-certificates / /
 COPY --from=pkg-fhs / /
@@ -125,7 +125,7 @@ COPY --from=pkg-musl / /
 COPY --from=pkg-libressl / /
 COPY --from=pkg-ipmitool / /
 COPY --from=build-caps-controller-manager /manager /manager
-LABEL org.opencontainers.image.source https://github.com/talos-systems/sidero
+LABEL org.opencontainers.image.source https://github.com/siderolabs/sidero
 ENTRYPOINT [ "/manager" ]
 
 FROM base AS build-sidero-controller-manager
@@ -214,7 +214,7 @@ COPY --from=build-log-receiver /log-receiver /log-receiver
 COPY --from=build-events-manager /events-manager /events-manager
 
 FROM sidero-controller-manager-image AS sidero-controller-manager
-LABEL org.opencontainers.image.source https://github.com/talos-systems/sidero
+LABEL org.opencontainers.image.source https://github.com/siderolabs/sidero
 ENTRYPOINT [ "/manager" ]
 
 FROM base AS unit-tests-runner

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY ?= ghcr.io
-USERNAME ?= talos-systems
+USERNAME ?= siderolabs
 SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
@@ -13,7 +13,7 @@ TALOS_RELEASE ?= v0.14.1
 PREVIOUS_TALOS_RELEASE ?= v0.13.4
 DEFAULT_K8S_VERSION ?= v1.22.3
 
-TOOLS ?= ghcr.io/talos-systems/tools:v0.10.0-alpha.0-3-g4c9e7a4
+TOOLS ?= ghcr.io/siderolabs/tools:v1.0.0
 PKGS ?= v0.10.0-alpha.0-24-g6019223
 
 SFYRA_CLUSTERCTL_CONFIG ?= $(HOME)/.cluster-api/clusterctl.sfyra.yaml
@@ -148,7 +148,7 @@ release-notes:
 
 $(ARTIFACTS)/$(TALOS_RELEASE)/%:
 	@mkdir -p $(ARTIFACTS)/$(TALOS_RELEASE)/
-	@curl -L -o "$(ARTIFACTS)/$(TALOS_RELEASE)/$*" "https://github.com/talos-systems/talos/releases/download/$(TALOS_RELEASE)/$*"
+	@curl -L -o "$(ARTIFACTS)/$(TALOS_RELEASE)/$*" "https://github.com/siderolabs/talos/releases/download/$(TALOS_RELEASE)/$*"
 
 .PHONY: $(ARTIFACTS)/$(TALOS_RELEASE)
 $(ARTIFACTS)/$(TALOS_RELEASE): $(ARTIFACTS)/$(TALOS_RELEASE)/vmlinuz-amd64 $(ARTIFACTS)/$(TALOS_RELEASE)/initramfs-amd64.xz $(ARTIFACTS)/$(TALOS_RELEASE)/talosctl-linux-amd64
@@ -224,7 +224,7 @@ unit-tests-race: ## Performs unit tests with race detection enabled.
 
 .PHONY: conformance
 conformance: ## Performs policy checks against the commit and source code.
-	docker run --rm -it -v $(PWD):/src -w /src ghcr.io/talos-systems/conform:v0.1.0-alpha.22 enforce
+	docker run --rm -it -v $(PWD):/src -w /src ghcr.io/siderolabs/conform:v0.1.0-alpha.22 enforce
 
 .PHONY: clean
 clean:

--- a/app/caps-controller-manager/PROJECT
+++ b/app/caps-controller-manager/PROJECT
@@ -1,5 +1,5 @@
 domain: cluster.x-k8s.io
-repo: github.com/talos-systems/sidero/app/caps-controller-manager
+repo: github.com/siderolabs/sidero/app/caps-controller-manager
 resources:
 - group: infrastructure
   kind: MetalCluster

--- a/app/sidero-controller-manager/PROJECT
+++ b/app/sidero-controller-manager/PROJECT
@@ -1,5 +1,5 @@
 domain: sidero.dev
-repo: github.com/talos-systems/sidero/app/sidero-controller-manager
+repo: github.com/siderolabs/sidero/app/sidero-controller-manager
 resources:
 - group: metal
   kind: Environment

--- a/app/sidero-controller-manager/api/v1alpha1/environment_types.go
+++ b/app/sidero-controller-manager/api/v1alpha1/environment_types.go
@@ -84,13 +84,13 @@ func EnvironmentDefaultSpec(talosRelease, apiEndpoint string, apiPort uint16) *E
 	return &EnvironmentSpec{
 		Kernel: Kernel{
 			Asset: Asset{
-				URL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/vmlinuz-amd64", talosRelease),
+				URL: fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/vmlinuz-amd64", talosRelease),
 			},
 			Args: args,
 		},
 		Initrd: Initrd{
 			Asset: Asset{
-				URL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/initramfs-amd64.xz", talosRelease),
+				URL: fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/initramfs-amd64.xz", talosRelease),
 			},
 		},
 	}

--- a/app/sidero-controller-manager/config/samples/metal_v1alpha1_environment.yaml
+++ b/app/sidero-controller-manager/config/samples/metal_v1alpha1_environment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.10.3/vmlinuz-amd64"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.10.3/vmlinuz-amd64"
     sha512: ""
     args:
       - console=tty0
@@ -24,5 +24,5 @@ spec:
       - talos.config=http://192.168.1.10:8081/configdata?uuid=
       - talos.platform=metal
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.10.3/initramfs-amd64.xz"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.10.3/initramfs-amd64.xz"
     sha512: ""

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-RELEASE_TOOL_IMAGE="ghcr.io/talos-systems/release-tool:latest"
+RELEASE_TOOL_IMAGE="ghcr.io/siderolabs/release-tool:latest"
 
 function release-tool {
   docker pull "${RELEASE_TOOL_IMAGE}" >/dev/null

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -2,8 +2,8 @@
 commit = "HEAD"
 
 project_name = "Sidero"
-github_repo = "talos-systems/sidero"
-match_deps = "^github.com/(talos-systems/[a-zA-Z0-9-]+)$"
+github_repo = "siderolabs/sidero"
+match_deps = "^github.com/((talos-systems|siderolabs)/[a-zA-Z0-9-]+)$"
 
 # previous release
 previous = "v0.4.0"

--- a/hack/scripts/generate-clusterctl-config.sh
+++ b/hack/scripts/generate-clusterctl-config.sh
@@ -9,4 +9,10 @@ providers:
   - name: "sidero"
     url: "file://${COMPONENTS_YAML}"
     type: "InfrastructureProvider"
+  - name: "talos"
+    url: "https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/releases/latest/bootstrap-components.yaml"
+    type: "BootstrapProvider"
+  - name: "talos"
+    url: "https://github.com/siderolabs/cluster-api-control-plane-provider-talos/releases/latest/control-plane-components.yaml"
+    type: "ControlPlaneProvider"
 EOF

--- a/sfyra/cmd/sfyra/cmd/options.go
+++ b/sfyra/cmd/sfyra/cmd/options.go
@@ -61,12 +61,12 @@ func DefaultOptions() Options {
 		BootstrapClusterName:    "sfyra",
 		BootstrapTalosVmlinuz:   fmt.Sprintf("_out/%s/vmlinuz-amd64", TalosRelease),
 		BootstrapTalosInitramfs: fmt.Sprintf("_out/%s/initramfs-amd64.xz", TalosRelease),
-		BootstrapTalosInstaller: fmt.Sprintf("ghcr.io/talos-systems/installer:%s", TalosRelease),
-		BootstrapCNIBundleURL:   fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/talosctl-cni-bundle-%s.tar.gz", TalosRelease, "amd64"),
+		BootstrapTalosInstaller: fmt.Sprintf("ghcr.io/siderolabs/installer:%s", TalosRelease),
+		BootstrapCNIBundleURL:   fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/talosctl-cni-bundle-%s.tar.gz", TalosRelease, "amd64"),
 		BootstrapCIDR:           "172.24.0.0/24",
 
-		TalosKernelURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/vmlinuz-amd64", TalosRelease),
-		TalosInitrdURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/initramfs-amd64.xz", TalosRelease),
+		TalosKernelURL: fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/vmlinuz-amd64", TalosRelease),
+		TalosInitrdURL: fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/initramfs-amd64.xz", TalosRelease),
 
 		CoreProvider:            "cluster-api",
 		BootstrapProviders:      []string{"talos"},

--- a/sfyra/pkg/tests/compatibility.go
+++ b/sfyra/pkg/tests/compatibility.go
@@ -59,10 +59,10 @@ func TestCompatibilityCluster(ctx context.Context, metalClient client.Client, cl
 
 			environment.APIVersion = constants.SideroAPIVersion
 			environment.Name = envName
-			environment.Spec.Kernel.URL = fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/vmlinuz-amd64", talosRelease)
+			environment.Spec.Kernel.URL = fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/vmlinuz-amd64", talosRelease)
 			environment.Spec.Kernel.SHA512 = ""
 			environment.Spec.Kernel.Args = cmdline.Strings()
-			environment.Spec.Initrd.URL = fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/initramfs-amd64.xz", talosRelease)
+			environment.Spec.Initrd.URL = fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/initramfs-amd64.xz", talosRelease)
 			environment.Spec.Initrd.SHA512 = ""
 
 			require.NoError(t, metalClient.Create(ctx, &environment))

--- a/website/content/docs/v0.1/Guides/bootstrapping.md
+++ b/website/content/docs/v0.1/Guides/bootstrapping.md
@@ -18,7 +18,7 @@ Talos Systems and the Cluster API community have created tools to help make this
 First, you need to install the latest `talosctl` by running the following script:
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -196,7 +196,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/latest/download/vmlinuz-amd64"
+    url: "https://github.com/siderolabs/talos/releases/latest/download/vmlinuz-amd64"
     sha512: ""
     args:
       - initrd=initramfs.xz
@@ -216,7 +216,7 @@ spec:
       - talos.platform=metal
       - talos.config=http://$PUBLIC_IP:9091/configdata?uuid=
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/latest/download/initramfs-amd64.xz"
+    url: "https://github.com/siderolabs/talos/releases/latest/download/initramfs-amd64.xz"
     sha512: ""
 EOF
 ```

--- a/website/content/docs/v0.1/Overview/introduction.md
+++ b/website/content/docs/v0.1/Overview/introduction.md
@@ -4,10 +4,10 @@ weight: 1
 title: Introduction
 ---
 
-Sidero ("Iron" in Greek) is a project created by the [Talos Systems](https://www.talos-systems.com/) team.
+Sidero ("Iron" in Greek) is a project created by the [Siderolabs](https://www.siderolabs.com/) team.
 The goal of this project is to provide lightweight, composable tools that can be used to create bare-metal Talos + Kubernetes clusters.
 These tools are built around the Cluster API project.
-Sidero is also a subproject of Talos Systems' [Arges](https://github.com/talos-systems/arges) project, which will publish known-good versions of these components (along with others) with each release.
+Sidero is also a subproject of Siderolabs' [Arges](https://github.com/siderolabs/arges) project, which will publish known-good versions of these components (along with others) with each release.
 
 ## Overview
 
@@ -20,12 +20,12 @@ Sidero is made currently made up of three components:
 Sidero also needs these co-requisites in order to be useful:
 
 - [Cluster API](https://github.com/kubernetes-sigs/cluster-api)
-- [Cluster API Control Plane Provider Talos](https://github.com/talos-systems/cluster-api-control-plane-provider-talos)
-- [Cluster API Bootstrap Provider Talos](https://github.com/talos-systems/cluster-api-bootstrap-provider-talos)
+- [Cluster API Control Plane Provider Talos](https://github.com/siderolabs/cluster-api-control-plane-provider-talos)
+- [Cluster API Bootstrap Provider Talos](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos)
 
 All componenets mentioned above can be installed using Cluster API's `clusterctl` tool.
 
 Because of the design of Cluster API, there is inherently a "chicken and egg" problem with needing an existing Kubernetes cluster in order to provision the management plane.
-Talos Systems and the Cluster API community have created tools to help make this transition easier.
+Siderolabs and the Cluster API community have created tools to help make this transition easier.
 That being said, the management plane cluster does not have to be based on Talos.
 If you would, however, like to use Talos as the OS of choice for the Sidero management plane, you can find a number of ways to deploy Talos in the [documentation](https://www.talos.dev).

--- a/website/content/docs/v0.1/Overview/resources.md
+++ b/website/content/docs/v0.1/Overview/resources.md
@@ -6,7 +6,7 @@ title: Resources
 
 Sidero, the Talos bootstrap/controlplane providers, and Cluster API each provide several custom resources (CRDs) to Kubernetes.
 These CRDs are crucial to understanding the connections between each provider and in troubleshooting problems.
-It may also help to look at the [cluster template](https://github.com/talos-systems/sidero/blob/master/templates/cluster-template.yaml) to get an idea of the relationships between these.
+It may also help to look at the [cluster template](https://github.com/siderolabs/sidero/blob/master/templates/cluster-template.yaml) to get an idea of the relationships between these.
 
 ---
 

--- a/website/content/docs/v0.1/Resource Configuration/environments.md
+++ b/website/content/docs/v0.1/Resource Configuration/environments.md
@@ -26,7 +26,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.8.1/vmlinuz-amd64"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.8.1/vmlinuz-amd64"
     sha512: ""
     args:
       - init_on_alloc=1
@@ -46,7 +46,7 @@ spec:
       - talos.platform=metal
       - talos.config=http://$PUBLIC_IP:9091/configdata?uuid=
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.8.1/initramfs-amd64.xz"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.8.1/initramfs-amd64.xz"
     sha512: ""
 ```
 

--- a/website/content/docs/v0.1/index.md
+++ b/website/content/docs/v0.1/index.md
@@ -6,10 +6,10 @@ Welcome to the Sidero documentation.
 
 ## Community
 
-- Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
+- Slack: Join our [slack channel](https://slack.dev.siderolabs.io)
 - Forum: [community](https://groups.google.com/a/SideroLabs.com/forum/#!forum/community)
 - Twitter: [@talossystems](https://twitter.com/SideroLabs)
-- Email: [info@talos-systems.com](mailto:info@SideroLabs.com)
+- Email: [info@siderolabs.com](mailto:info@SideroLabs.com)
 
 If you're interested in this project and would like to help in engineering efforts, or have general usage questions, we are happy to have you!
 We hold a weekly meeting that all audiences are welcome to attend.

--- a/website/content/docs/v0.2/Getting Started/prereq-cli-tools.md
+++ b/website/content/docs/v0.2/Getting Started/prereq-cli-tools.md
@@ -48,10 +48,10 @@ sudo chmod +x /usr/local/bin/clusterctl
 The `talosctl` tool is used to interact with the Talos (our Kubernetes-focused
 operating system) API.
 The latest version can be found on our
-[Releases](https://github.com/talos-systems/talos/releases) page.
+[Releases](https://github.com/siderolabs/talos/releases) page.
 
 ```bash
 sudo curl -Lo /usr/local/bin/talosctl \
- "https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
+ "https://github.com/siderolabs/talos/releases/latest/download/talosctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
 chmod +x /usr/local/bin/talosctl
 ```

--- a/website/content/docs/v0.2/Guides/bootstrapping.md
+++ b/website/content/docs/v0.2/Guides/bootstrapping.md
@@ -18,7 +18,7 @@ Talos Systems and the Cluster API community have created tools to help make this
 First, you need to install the latest `talosctl` by running the following script:
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -196,7 +196,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/latest/download/vmlinuz-amd64"
+    url: "https://github.com/siderolabs/talos/releases/latest/download/vmlinuz-amd64"
     sha512: ""
     args:
       - initrd=initramfs.xz
@@ -216,7 +216,7 @@ spec:
       - talos.platform=metal
       - talos.config=http://$PUBLIC_IP:9091/configdata?uuid=
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/latest/download/initramfs-amd64.xz"
+    url: "https://github.com/siderolabs/talos/releases/latest/download/initramfs-amd64.xz"
     sha512: ""
 EOF
 ```

--- a/website/content/docs/v0.2/Overview/introduction.md
+++ b/website/content/docs/v0.2/Overview/introduction.md
@@ -4,10 +4,10 @@ weight: 1
 title: Introduction
 ---
 
-Sidero ("Iron" in Greek) is a project created by the [Talos Systems](https://www.talos-systems.com/) team.
+Sidero ("Iron" in Greek) is a project created by the [Siderolabs](https://www.siderolabs.com/) team.
 The goal of this project is to provide lightweight, composable tools that can be used to create bare-metal Talos + Kubernetes clusters.
 These tools are built around the Cluster API project.
-Sidero is also a subproject of Talos Systems' [Arges](https://github.com/talos-systems/arges) project, which will publish known-good versions of these components (along with others) with each release.
+Sidero is also a subproject of Siderolabs' [Arges](https://github.com/siderolabs/arges) project, which will publish known-good versions of these components (along with others) with each release.
 
 ## Overview
 
@@ -20,12 +20,12 @@ Sidero is made currently made up of three components:
 Sidero also needs these co-requisites in order to be useful:
 
 - [Cluster API](https://github.com/kubernetes-sigs/cluster-api)
-- [Cluster API Control Plane Provider Talos](https://github.com/talos-systems/cluster-api-control-plane-provider-talos)
-- [Cluster API Bootstrap Provider Talos](https://github.com/talos-systems/cluster-api-bootstrap-provider-talos)
+- [Cluster API Control Plane Provider Talos](https://github.com/siderolabs/cluster-api-control-plane-provider-talos)
+- [Cluster API Bootstrap Provider Talos](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos)
 
 All componenets mentioned above can be installed using Cluster API's `clusterctl` tool.
 
 Because of the design of Cluster API, there is inherently a "chicken and egg" problem with needing an existing Kubernetes cluster in order to provision the management plane.
-Talos Systems and the Cluster API community have created tools to help make this transition easier.
+Siderolabs and the Cluster API community have created tools to help make this transition easier.
 That being said, the management plane cluster does not have to be based on Talos.
 If you would, however, like to use Talos as the OS of choice for the Sidero management plane, you can find a number of ways to deploy Talos in the [documentation](https://www.talos.dev).

--- a/website/content/docs/v0.2/Overview/resources.md
+++ b/website/content/docs/v0.2/Overview/resources.md
@@ -6,7 +6,7 @@ title: Resources
 
 Sidero, the Talos bootstrap/controlplane providers, and Cluster API each provide several custom resources (CRDs) to Kubernetes.
 These CRDs are crucial to understanding the connections between each provider and in troubleshooting problems.
-It may also help to look at the [cluster template](https://github.com/talos-systems/sidero/blob/master/templates/cluster-template.yaml) to get an idea of the relationships between these.
+It may also help to look at the [cluster template](https://github.com/siderolabs/sidero/blob/master/templates/cluster-template.yaml) to get an idea of the relationships between these.
 
 ---
 

--- a/website/content/docs/v0.2/Resource Configuration/environments.md
+++ b/website/content/docs/v0.2/Resource Configuration/environments.md
@@ -26,7 +26,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.8.1/vmlinuz-amd64"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.8.1/vmlinuz-amd64"
     sha512: ""
     args:
       - init_on_alloc=1
@@ -46,7 +46,7 @@ spec:
       - talos.platform=metal
       - talos.config=http://$PUBLIC_IP:9091/configdata?uuid=
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.8.1/initramfs-amd64.xz"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.8.1/initramfs-amd64.xz"
     sha512: ""
 ```
 

--- a/website/content/docs/v0.2/index.md
+++ b/website/content/docs/v0.2/index.md
@@ -6,10 +6,10 @@ Welcome to the Sidero documentation.
 
 ## Community
 
-- Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
+- Slack: Join our [slack channel](https://slack.dev.siderolabs.io)
 - Forum: [community](https://groups.google.com/a/SideroLabs.com/forum/#!forum/community)
 - Twitter: [@talossystems](https://twitter.com/SideroLabs)
-- Email: [info@talos-systems.com](mailto:info@SideroLabs.com)
+- Email: [info@siderolabs.com](mailto:info@SideroLabs.com)
 
 If you're interested in this project and would like to help in engineering efforts, or have general usage questions, we are happy to have you!
 We hold a weekly meeting that all audiences are welcome to attend.

--- a/website/content/docs/v0.3/Getting Started/prereq-cli-tools.md
+++ b/website/content/docs/v0.3/Getting Started/prereq-cli-tools.md
@@ -51,10 +51,10 @@ sudo chmod +x /usr/local/bin/clusterctl
 The `talosctl` tool is used to interact with the Talos (our Kubernetes-focused
 operating system) API.
 The latest version can be found on our
-[Releases](https://github.com/talos-systems/talos/releases) page.
+[Releases](https://github.com/siderolabs/talos/releases) page.
 
 ```bash
 sudo curl -Lo /usr/local/bin/talosctl \
- "https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
+ "https://github.com/siderolabs/talos/releases/latest/download/talosctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
 chmod +x /usr/local/bin/talosctl
 ```

--- a/website/content/docs/v0.3/Guides/bootstrapping.md
+++ b/website/content/docs/v0.3/Guides/bootstrapping.md
@@ -18,7 +18,7 @@ Talos Systems and the Cluster API community have created tools to help make this
 First, you need to install the latest `talosctl` by running the following script:
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 

--- a/website/content/docs/v0.3/Guides/rpi4-as-servers.md
+++ b/website/content/docs/v0.3/Guides/rpi4-as-servers.md
@@ -61,9 +61,9 @@ first line under the Pi logo will be something like the following:
 
 Write down the 8 character serial.
 
-### talos-systems/pkg
+### siderolabs/pkg
 
-Clone the [talos-systems/pkg](https://github.com/talos-systems/pkgs) repo.
+Clone the [siderolabs/pkg](https://github.com/siderolabs/pkgs) repo.
 Create a new folder called `raspberrypi4-uefi` and `raspberrypi4-uefi/serials`.
 Create a file `raspberrypi4-uefi/pkg.yaml` containing the following:
 

--- a/website/content/docs/v0.3/Overview/introduction.md
+++ b/website/content/docs/v0.3/Overview/introduction.md
@@ -4,10 +4,10 @@ weight: 1
 title: Introduction
 ---
 
-Sidero ("Iron" in Greek) is a project created by the [Talos Systems](https://www.talos-systems.com/) team.
+Sidero ("Iron" in Greek) is a project created by the [Siderolabs](https://www.siderolabs.com/) team.
 The goal of this project is to provide lightweight, composable tools that can be used to create bare-metal Talos + Kubernetes clusters.
 These tools are built around the Cluster API project.
-Sidero is also a subproject of Talos Systems' [Arges](https://github.com/talos-systems/arges) project, which will publish known-good versions of these components (along with others) with each release.
+Sidero is also a subproject of Siderolabs' [Arges](https://github.com/siderolabs/arges) project, which will publish known-good versions of these components (along with others) with each release.
 
 ## Overview
 
@@ -19,12 +19,12 @@ Sidero is currently made up of two components:
 Sidero also needs these co-requisites in order to be useful:
 
 - [Cluster API](https://github.com/kubernetes-sigs/cluster-api)
-- [Cluster API Control Plane Provider Talos](https://github.com/talos-systems/cluster-api-control-plane-provider-talos)
-- [Cluster API Bootstrap Provider Talos](https://github.com/talos-systems/cluster-api-bootstrap-provider-talos)
+- [Cluster API Control Plane Provider Talos](https://github.com/siderolabs/cluster-api-control-plane-provider-talos)
+- [Cluster API Bootstrap Provider Talos](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos)
 
 All components mentioned above can be installed using Cluster API's `clusterctl` tool.
 
 Because of the design of Cluster API, there is inherently a "chicken and egg" problem with needing an existing Kubernetes cluster in order to provision the management plane.
-Talos Systems and the Cluster API community have created tools to help make this transition easier.
+Siderolabs and the Cluster API community have created tools to help make this transition easier.
 That being said, the management plane cluster does not have to be based on Talos.
 If you would, however, like to use Talos as the OS of choice for the Sidero management plane, you can find a number of ways to deploy Talos in the [documentation](https://www.talos.dev).

--- a/website/content/docs/v0.3/Overview/resources.md
+++ b/website/content/docs/v0.3/Overview/resources.md
@@ -6,7 +6,7 @@ title: Resources
 
 Sidero, the Talos bootstrap/controlplane providers, and Cluster API each provide several custom resources (CRDs) to Kubernetes.
 These CRDs are crucial to understanding the connections between each provider and in troubleshooting problems.
-It may also help to look at the [cluster template](https://github.com/talos-systems/sidero/blob/master/templates/cluster-template.yaml) to get an idea of the relationships between these.
+It may also help to look at the [cluster template](https://github.com/siderolabs/sidero/blob/master/templates/cluster-template.yaml) to get an idea of the relationships between these.
 
 ---
 

--- a/website/content/docs/v0.3/Resource Configuration/environments.md
+++ b/website/content/docs/v0.3/Resource Configuration/environments.md
@@ -26,7 +26,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.10.3/vmlinuz-amd64"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.10.3/vmlinuz-amd64"
     sha512: ""
     args:
       - console=tty0
@@ -46,7 +46,7 @@ spec:
       - talos.config=http://$PUBLIC_IP:8081/configdata?uuid=
       - talos.platform=metal
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.10.3/initramfs-amd64.xz"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.10.3/initramfs-amd64.xz"
     sha512: ""
 ```
 

--- a/website/content/docs/v0.3/index.md
+++ b/website/content/docs/v0.3/index.md
@@ -6,10 +6,10 @@ Welcome to the Sidero documentation.
 
 ## Community
 
-- Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
+- Slack: Join our [slack channel](https://slack.dev.siderolabs.io)
 - Forum: [community](https://groups.google.com/a/SideroLabs.com/forum/#!forum/community)
 - Twitter: [@talossystems](https://twitter.com/SideroLabs)
-- Email: [info@talos-systems.com](mailto:info@SideroLabs.com)
+- Email: [info@siderolabs.com](mailto:info@SideroLabs.com)
 
 If you're interested in this project and would like to help in engineering efforts, or have general usage questions, we are happy to have you!
 We hold a weekly meeting that all audiences are welcome to attend.

--- a/website/content/docs/v0.4/Getting Started/prereq-cli-tools.md
+++ b/website/content/docs/v0.4/Getting Started/prereq-cli-tools.md
@@ -52,10 +52,10 @@ sudo chmod +x /usr/local/bin/clusterctl
 The `talosctl` tool is used to interact with the Talos (our Kubernetes-focused
 operating system) API.
 The latest version can be found on our
-[Releases](https://github.com/talos-systems/talos/releases) page.
+[Releases](https://github.com/siderolabs/talos/releases) page.
 
 ```bash
 sudo curl -Lo /usr/local/bin/talosctl \
- "https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
+ "https://github.com/siderolabs/talos/releases/latest/download/talosctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
 chmod +x /usr/local/bin/talosctl
 ```

--- a/website/content/docs/v0.4/Guides/bootstrapping.md
+++ b/website/content/docs/v0.4/Guides/bootstrapping.md
@@ -18,7 +18,7 @@ Talos Systems and the Cluster API community have created tools to help make this
 First, you need to install the latest `talosctl` by running the following script:
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 

--- a/website/content/docs/v0.4/Guides/rpi4-as-servers.md
+++ b/website/content/docs/v0.4/Guides/rpi4-as-servers.md
@@ -61,9 +61,9 @@ first line under the Pi logo will be something like the following:
 
 Write down the 8 character serial.
 
-### talos-systems/pkg
+### siderolabs/pkg
 
-Clone the [talos-systems/pkg](https://github.com/talos-systems/pkgs) repo.
+Clone the [siderolabs/pkg](https://github.com/siderolabs/pkgs) repo.
 Create a new folder called `raspberrypi4-uefi` and `raspberrypi4-uefi/serials`.
 Create a file `raspberrypi4-uefi/pkg.yaml` containing the following:
 

--- a/website/content/docs/v0.4/Overview/introduction.md
+++ b/website/content/docs/v0.4/Overview/introduction.md
@@ -22,8 +22,8 @@ Sidero Metal is currently made up of two components:
 Sidero Metal also needs these co-requisites in order to be useful:
 
 - [Cluster API](https://github.com/kubernetes-sigs/cluster-api)
-- [Cluster API Control Plane Provider Talos](https://github.com/talos-systems/cluster-api-control-plane-provider-talos)
-- [Cluster API Bootstrap Provider Talos](https://github.com/talos-systems/cluster-api-bootstrap-provider-talos)
+- [Cluster API Control Plane Provider Talos](https://github.com/siderolabs/cluster-api-control-plane-provider-talos)
+- [Cluster API Bootstrap Provider Talos](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos)
 
 All components mentioned above can be installed using Cluster API's `clusterctl` tool.
 See the [Getting Started](../../getting-started/) for more details.

--- a/website/content/docs/v0.4/Overview/resources.md
+++ b/website/content/docs/v0.4/Overview/resources.md
@@ -6,7 +6,7 @@ title: Resources
 
 Sidero, the Talos bootstrap/controlplane providers, and Cluster API each provide several custom resources (CRDs) to Kubernetes.
 These CRDs are crucial to understanding the connections between each provider and in troubleshooting problems.
-It may also help to look at the [cluster template](https://github.com/talos-systems/sidero/blob/master/templates/cluster-template.yaml) to get an idea of the relationships between these.
+It may also help to look at the [cluster template](https://github.com/siderolabs/sidero/blob/master/templates/cluster-template.yaml) to get an idea of the relationships between these.
 
 ---
 

--- a/website/content/docs/v0.4/Resource Configuration/environments.md
+++ b/website/content/docs/v0.4/Resource Configuration/environments.md
@@ -26,7 +26,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.13.3/vmlinuz-amd64"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.13.3/vmlinuz-amd64"
     sha512: ""
     args:
       - console=tty0
@@ -45,7 +45,7 @@ spec:
       - slab_nomerge=
       - talos.platform=metal
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.13.3/initramfs-amd64.xz"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.13.3/initramfs-amd64.xz"
     sha512: ""
 ```
 

--- a/website/content/docs/v0.4/index.md
+++ b/website/content/docs/v0.4/index.md
@@ -6,10 +6,10 @@ Welcome to the Sidero documentation.
 
 ## Community
 
-- Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
+- Slack: Join our [slack channel](https://slack.dev.siderolabs.io)
 - Forum: [community](https://groups.google.com/a/SideroLabs.com/forum/#!forum/community)
 - Twitter: [@talossystems](https://twitter.com/SideroLabs)
-- Email: [info@talos-systems.com](mailto:info@SideroLabs.com)
+- Email: [info@siderolabs.com](mailto:info@SideroLabs.com)
 
 If you're interested in this project and would like to help in engineering efforts, or have general usage questions, we are happy to have you!
 We hold a weekly meeting that all audiences are welcome to attend.

--- a/website/content/docs/v0.5/Getting Started/prereq-cli-tools.md
+++ b/website/content/docs/v0.5/Getting Started/prereq-cli-tools.md
@@ -51,10 +51,10 @@ sudo chmod +x /usr/local/bin/clusterctl
 The `talosctl` tool is used to interact with the Talos (our Kubernetes-focused
 operating system) API.
 The latest version can be found on our
-[Releases](https://github.com/talos-systems/talos/releases) page.
+[Releases](https://github.com/siderolabs/talos/releases) page.
 
 ```bash
 sudo curl -Lo /usr/local/bin/talosctl \
- "https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
+ "https://github.com/siderolabs/talos/releases/latest/download/talosctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
 chmod +x /usr/local/bin/talosctl
 ```

--- a/website/content/docs/v0.5/Guides/bootstrapping.md
+++ b/website/content/docs/v0.5/Guides/bootstrapping.md
@@ -18,7 +18,7 @@ Talos Systems and the Cluster API community have created tools to help make this
 First, you need to install the latest `talosctl` by running the following script:
 
 ```bash
-curl -Lo /usr/local/bin/talosctl https://github.com/talos-systems/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
+curl -Lo /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/latest/download/talosctl-$(uname -s | tr "[:upper:]" "[:lower:]")-amd64
 chmod +x /usr/local/bin/talosctl
 ```
 
@@ -115,6 +115,8 @@ We're really looking for the IP of your machine, not the IP of the node on the d
 ```bash
 export PUBLIC_IP="192.168.1.150"
 ```
+
+> Note: Before you create the local cluster you should ensure that wireguard module is installed on your host OS.
 
 We can now create our Docker cluster.
 Issue the following to create a single-node cluster:

--- a/website/content/docs/v0.5/Guides/rpi4-as-servers.md
+++ b/website/content/docs/v0.5/Guides/rpi4-as-servers.md
@@ -61,9 +61,9 @@ first line under the Pi logo will be something like the following:
 
 Write down the 8 character serial.
 
-### talos-systems/pkg
+### siderolabs/pkg
 
-Clone the [talos-systems/pkg](https://github.com/talos-systems/pkgs) repo.
+Clone the [siderolabs/pkg](https://github.com/siderolabs/pkgs) repo.
 Create a new folder called `raspberrypi4-uefi` and `raspberrypi4-uefi/serials`.
 Create a file `raspberrypi4-uefi/pkg.yaml` containing the following:
 

--- a/website/content/docs/v0.5/Overview/introduction.md
+++ b/website/content/docs/v0.5/Overview/introduction.md
@@ -22,8 +22,8 @@ Sidero Metal is currently made up of two components:
 Sidero Metal also needs these co-requisites in order to be useful:
 
 - [Cluster API](https://github.com/kubernetes-sigs/cluster-api)
-- [Cluster API Control Plane Provider Talos](https://github.com/talos-systems/cluster-api-control-plane-provider-talos)
-- [Cluster API Bootstrap Provider Talos](https://github.com/talos-systems/cluster-api-bootstrap-provider-talos)
+- [Cluster API Control Plane Provider Talos](https://github.com/siderolabs/cluster-api-control-plane-provider-talos)
+- [Cluster API Bootstrap Provider Talos](https://github.com/siderolabs/cluster-api-bootstrap-provider-talos)
 
 All components mentioned above can be installed using Cluster API's `clusterctl` tool.
 See the [Getting Started](../../getting-started/) for more details.

--- a/website/content/docs/v0.5/Overview/resources.md
+++ b/website/content/docs/v0.5/Overview/resources.md
@@ -6,7 +6,7 @@ title: Resources
 
 Sidero, the Talos bootstrap/controlplane providers, and Cluster API each provide several custom resources (CRDs) to Kubernetes.
 These CRDs are crucial to understanding the connections between each provider and in troubleshooting problems.
-It may also help to look at the [cluster template](https://github.com/talos-systems/sidero/blob/master/templates/cluster-template.yaml) to get an idea of the relationships between these.
+It may also help to look at the [cluster template](https://github.com/siderolabs/sidero/blob/master/templates/cluster-template.yaml) to get an idea of the relationships between these.
 
 ---
 

--- a/website/content/docs/v0.5/Overview/whatsnew.md
+++ b/website/content/docs/v0.5/Overview/whatsnew.md
@@ -14,7 +14,7 @@ Sidero ships with new cluster template without `init` nodes.
 This template is only compatible with Talos >= 0.14 (it requires SideroLink feature which was introduced in Talos 0.14).
 
 On upgrade, Sidero supports clusters running Talos < 0.14 if they were created before the upgrade.
-Use [legacy template](https://github.com/talos-systems/sidero/blob/release-0.4/templates/cluster-template.yaml) to deploy clusters with Talos < 0.14.
+Use [legacy template](https://github.com/siderolabs/sidero/blob/release-0.4/templates/cluster-template.yaml) to deploy clusters with Talos < 0.14.
 
 ### New `MetalMachines` Conditions
 

--- a/website/content/docs/v0.5/Resource Configuration/environments.md
+++ b/website/content/docs/v0.5/Resource Configuration/environments.md
@@ -26,7 +26,7 @@ metadata:
   name: default
 spec:
   kernel:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.14.0/vmlinuz-amd64"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.14.0/vmlinuz-amd64"
     sha512: ""
     args:
       - console=tty0
@@ -45,7 +45,7 @@ spec:
       - slab_nomerge=
       - talos.platform=metal
   initrd:
-    url: "https://github.com/talos-systems/talos/releases/download/v0.14.0/initramfs-amd64.xz"
+    url: "https://github.com/siderolabs/talos/releases/download/v0.14.0/initramfs-amd64.xz"
     sha512: ""
 ```
 

--- a/website/content/docs/v0.5/index.md
+++ b/website/content/docs/v0.5/index.md
@@ -6,7 +6,7 @@ Welcome to the Sidero documentation.
 
 ## Community
 
-- Slack: Join our [slack channel](https://slack.dev.talos-systems.io)
+- Slack: Join our [slack channel](https://slack.dev.siderolabs.io)
 - Forum: [community](https://groups.google.com/a/SideroLabs.com/forum/#!forum/community)
 - Twitter: [@SideroLabs](https://twitter.com/SideroLabs)
 - Email: [info@SideroLabs.com](mailto:info@SideroLabs.com)

--- a/website/gridsome.config.js
+++ b/website/gridsome.config.js
@@ -16,7 +16,7 @@ module.exports = {
     description: "A bare metal provisioning system for managing Kubernetes clusters",
     web: process.env.URL_WEB || false,
     twitter: "https://twitter.com/SideroLabs",
-    github: "https://github.com/talos-systems/sidero",
+    github: "https://github.com/siderolabs/sidero",
     nav: {
       links: [{ path: "", title: "Docs" }],
     },


### PR DESCRIPTION
Pause siderolink container if it fails to set up the network.
Also update `talos-systems` references in Makefile`, `Dockerfile`, all
docs and tests.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>