### PR TITLE
refactor: remove pre-ServerBinding leftovers, use remote cached clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ MODULE := $(shell head -1 go.mod | cut -d' ' -f2)
 
 ARTIFACTS := _out
 TEST_PKGS ?= ./...
-TALOS_RELEASE ?= v1.0.0
+TALOS_RELEASE ?= v1.0.1
 PREVIOUS_TALOS_RELEASE ?= v0.13.4
-DEFAULT_K8S_VERSION ?= v1.22.3
+DEFAULT_K8S_VERSION ?= v1.23.5
 
 TOOLS ?= ghcr.io/siderolabs/tools:v1.0.0-1-g4c77d96
 PKGS ?= v1.1.0-alpha.0-17-g4dace49

--- a/app/sidero-controller-manager/api/v1alpha1/environment_types.go
+++ b/app/sidero-controller-manager/api/v1alpha1/environment_types.go
@@ -84,13 +84,13 @@ func EnvironmentDefaultSpec(talosRelease, apiEndpoint string, apiPort uint16) *E
 	return &EnvironmentSpec{
 		Kernel: Kernel{
 			Asset: Asset{
-				URL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/vmlinuz-amd64", talosRelease),
+				URL: fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/vmlinuz-amd64", talosRelease),
 			},
 			Args: args,
 		},
 		Initrd: Initrd{
 			Asset: Asset{
-				URL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/initramfs-amd64.xz", talosRelease),
+				URL: fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/initramfs-amd64.xz", talosRelease),
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
+	k8s.io/cluster-bootstrap v0.23.0 // indirect
 	k8s.io/component-base v0.23.5 // indirect
 	k8s.io/klog/v2 v2.30.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect

--- a/sfyra/cmd/sfyra/cmd/options.go
+++ b/sfyra/cmd/sfyra/cmd/options.go
@@ -61,12 +61,12 @@ func DefaultOptions() Options {
 		BootstrapClusterName:    "sfyra",
 		BootstrapTalosVmlinuz:   fmt.Sprintf("_out/%s/vmlinuz-amd64", TalosRelease),
 		BootstrapTalosInitramfs: fmt.Sprintf("_out/%s/initramfs-amd64.xz", TalosRelease),
-		BootstrapTalosInstaller: fmt.Sprintf("ghcr.io/talos-systems/installer:%s", TalosRelease),
-		BootstrapCNIBundleURL:   fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/talosctl-cni-bundle-%s.tar.gz", TalosRelease, "amd64"),
+		BootstrapTalosInstaller: fmt.Sprintf("ghcr.io/siderolabs/installer:%s", TalosRelease),
+		BootstrapCNIBundleURL:   fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/talosctl-cni-bundle-%s.tar.gz", TalosRelease, "amd64"),
 		BootstrapCIDR:           "172.24.0.0/24",
 
-		TalosKernelURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/vmlinuz-amd64", TalosRelease),
-		TalosInitrdURL: fmt.Sprintf("https://github.com/talos-systems/talos/releases/download/%s/initramfs-amd64.xz", TalosRelease),
+		TalosKernelURL: fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/vmlinuz-amd64", TalosRelease),
+		TalosInitrdURL: fmt.Sprintf("https://github.com/siderolabs/talos/releases/download/%s/initramfs-amd64.xz", TalosRelease),
 
 		CoreProvider:            "cluster-api",
 		BootstrapProviders:      []string{"talos"},

--- a/sfyra/pkg/tests/tests.go
+++ b/sfyra/pkg/tests/tests.go
@@ -135,10 +135,6 @@ func Run(ctx context.Context, cluster talos.Cluster, vmSet *vm.Set, capiManager 
 			TestMachineDeploymentReconcile(ctx, metalClient),
 		},
 		{
-			"TestServerBindingReconcile",
-			TestServerBindingReconcile(ctx, metalClient),
-		},
-		{
 			"TestMetalMachineServerRefReconcile",
 			TestMetalMachineServerRefReconcile(ctx, metalClient),
 		},

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,1 +1,3 @@
 resources
+src
+.cache


### PR DESCRIPTION
This PR has two major changes:

* retire the code which supported seamless migration from
pre-ServerBinding era to ServerBindings: creating `ServerBinding` on the
fly from the `MetalMachine` and `Server`; as there's no migration path
from pre-ServerBinding Sidero to the new version, it's time to drop it
* instead of creating workload cluster Kubernetes client each time, use
CAPI standard class to cache the client; the problem with "leaking"
clients is that HTTP/2 clients are almost never gc'ed, so they stay in
memory keeping an open connection with keepalives going both ways, so
caching lowers the load both on the controller and the control plane
endpoint

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>