### PR TITLE
feat: make MetalMachineTemplate immutable

### DIFF
--- a/app/caps-controller-manager/api/v1alpha3/metalmachinetemplate_webhook.go
+++ b/app/caps-controller-manager/api/v1alpha3/metalmachinetemplate_webhook.go
@@ -5,11 +5,40 @@
 package v1alpha3
 
 import (
+	"github.com/google/go-cmp/cmp"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 func (r *MetalMachineTemplate) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(r).
 		Complete()
+}
+
+//+kubebuilder:webhook:verbs=create;update;delete,path=/validate-infrastructure-cluster-x-k8s-io-v1alpha3-metalmachinetemplate,mutating=false,failurePolicy=fail,groups=infrastructure.cluster.x-k8s.io,resources=metalmachinetemplates,versions=v1alpha3,name=vmetalmachinetemplates.infrastructure.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1
+
+var _ webhook.Validator = &MetalMachineTemplate{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (r *MetalMachineTemplate) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (r *MetalMachineTemplate) ValidateUpdate(oldRaw runtime.Object) error {
+	old := oldRaw.(*MetalMachineTemplate)
+
+	if !cmp.Equal(r.Spec, old.Spec) {
+		return apierrors.NewBadRequest("MetalMachineTemplate.Spec is immutable")
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (r *MetalMachineTemplate) ValidateDelete() error {
+	return nil
 }

--- a/app/caps-controller-manager/api/v1alpha3/zz_generated.deepcopy.go
+++ b/app/caps-controller-manager/api/v1alpha3/zz_generated.deepcopy.go
@@ -11,7 +11,7 @@ package v1alpha3
 
 import (
 	v1 "k8s.io/api/core/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/errors"
 )

--- a/app/caps-controller-manager/config/default/kustomization.yaml
+++ b/app/caps-controller-manager/config/default/kustomization.yaml
@@ -15,7 +15,7 @@ bases:
 
 patchesStrategicMerge:
   - manager_webhook_patch.yaml
-#  - webhookcainjection_patch.yaml
+  - webhookcainjection_patch.yaml
 
 vars:
   - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR

--- a/app/caps-controller-manager/config/webhook/kustomization.yaml
+++ b/app/caps-controller-manager/config/webhook/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - manifests.yaml
   - service.yaml
 
 configurations:

--- a/app/caps-controller-manager/config/webhook/manifests.yaml
+++ b/app/caps-controller-manager/config/webhook/manifests.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha3-metalmachinetemplate
+  failurePolicy: Fail
+  name: vmetalmachinetemplates.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - metalmachinetemplates
+  sideEffects: None

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
+	github.com/google/go-cmp v0.5.7
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onsi/ginkgo v1.16.5
@@ -63,7 +64,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect


### PR DESCRIPTION
This allows proper upgrades by replacing the `MetalMachineTemplate`.

If the `MetalMachineTemployment` is mutated, the changes are not rolled
out automatically.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>