### PR TITLE
fix: append Talos default kernel args even if there is some defined

### DIFF
--- a/app/sidero-controller-manager/internal/ipxe/ipxe_server.go
+++ b/app/sidero-controller-manager/internal/ipxe/ipxe_server.go
@@ -496,6 +496,7 @@ func appendTalosArguments(env *metalv1.Environment) {
 	logDeliveryPrefix := talosconstants.KernelParamLoggingKernel + "="
 	eventsSinkPrefix := talosconstants.KernelParamEventsSink + "="
 
+outer:
 	for _, prefix := range []string{
 		talosConfigPrefix,
 		sideroLinkPrefix,
@@ -505,7 +506,7 @@ func appendTalosArguments(env *metalv1.Environment) {
 		for _, arg := range args {
 			if strings.HasPrefix(arg, prefix) {
 				// Environment already has variable, skip it
-				return
+				continue outer
 			}
 		}
 


### PR DESCRIPTION
If the server or environment used by the machine had at least one kernel
param overriden, the `ipxe_server` was skipping adding all of them.

Instead of that skip only the parameters which were defined.

Signed-off-by: Artem Chernyshev <artem.chernyshev@talos-systems.com>