### PR TITLE
docs: use ipxe-sanboot for raspberry pi 4's

### DIFF
--- a/website/content/v0.5/Guides/rpi4-as-servers.md
+++ b/website/content/v0.5/Guides/rpi4-as-servers.md
@@ -261,6 +261,14 @@ Followed by this command to apply the patch:
 kubectl -n sidero-system patch deployments.apps sidero-controller-manager --patch "$(cat patch.yaml)"
 ```
 
+## Configure BootFromDiskMethod
+
+By default, Sidero will use iPXE's `exit` command to attempt to force boot from disk.
+On Raspberry Pi, this will drop you into the bootloader interface, and you will need to connect a keyboard and manually select the disk to boot from.
+
+The BootFromDiskMethod can be configured on individual [Servers](../../resource-configuration/servers/#bootfromdiskmethod), on [ServerClasses](../../resource-configuration/serverclasses/#bootfromdiskmethod), or as a command-line argument to the Sidero metal controller itself (`--boot-from-disk-method=<value>`).
+In order to force the Pi to use the configured bootloader order, the BootFromDiskMethod needs to be set to `ipxe-sanboot`.
+
 ## Profit
 
 With the patched metal controller, you should now be able to register the Pi4 to

--- a/website/content/v0.6/Guides/rpi4-as-servers.md
+++ b/website/content/v0.6/Guides/rpi4-as-servers.md
@@ -261,6 +261,14 @@ Followed by this command to apply the patch:
 kubectl -n sidero-system patch deployments.apps sidero-controller-manager --patch "$(cat patch.yaml)"
 ```
 
+## Configure BootFromDiskMethod
+
+By default, Sidero will use iPXE's `exit` command to attempt to force boot from disk.
+On Raspberry Pi, this will drop you into the bootloader interface, and you will need to connect a keyboard and manually select the disk to boot from.
+
+The BootFromDiskMethod can be configured on individual [Servers](../../resource-configuration/servers/#bootfromdiskmethod), on [ServerClasses](../../resource-configuration/serverclasses/#bootfromdiskmethod), or as a command-line argument to the Sidero metal controller itself (`--boot-from-disk-method=<value>`).
+In order to force the Pi to use the configured bootloader order, the BootFromDiskMethod needs to be set to `ipxe-sanboot`.
+
 ## Profit
 
 With the patched metal controller, you should now be able to register the Pi4 to


### PR DESCRIPTION
Updated "Raspberry Pi 4's as Servers" guide with learnings from [this](https://taloscommunity.slack.com/archives/CMARMBC4E/p1654714688959959) Slack thread.