### PR TITLE
fix: use http response writer directly

### DIFF
--- a/app/sidero-controller-manager/internal/ipxe/ipxe_server.go
+++ b/app/sidero-controller-manager/internal/ipxe/ipxe_server.go
@@ -120,7 +120,7 @@ var (
 )
 
 func bootFileHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, embeddedScriptBuf.Bytes())
+	w.Write(embeddedScriptBuf.Bytes())
 }
 
 //nolint:unparam


### PR DESCRIPTION
Fixes an issue with fmt.Fprint formatting byte arrays.

Fixes https://github.com/siderolabs/sidero/issues/889

I'm currently running with this change via `ghcr.io/bzub/sidero-controller-manager:v0.5.1-1-g7fe8dcb`.

Signed-off-by: bzub <bzub@users.noreply.github.com>
