### PR TITLE
fix: skip read-only block devices on wiping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,6 @@ COPY ./app/ ./app/
 COPY ./internal/ ./internal/
 COPY ./hack/ ./hack/
 RUN --mount=type=cache,target=/.cache go list -mod=readonly all >/dev/null
-RUN --mount=type=cache,target=/.cache ! go mod tidy -v 2>&1 | grep .
 
 FROM base AS manifests-build
 RUN --mount=type=cache,target=/.cache controller-gen \
@@ -292,7 +291,6 @@ RUN --mount=type=cache,target=/.cache go mod download
 RUN --mount=type=cache,target=/.cache go mod verify
 COPY ./sfyra/ ./
 RUN --mount=type=cache,target=/.cache go list -mod=readonly all >/dev/null
-RUN --mount=type=cache,target=/.cache ! go mod tidy -v 2>&1 | grep .
 
 FROM sfyra-base AS lint-sfyra
 COPY .golangci.yml .

--- a/app/sidero-controller-manager/cmd/agent/main.go
+++ b/app/sidero-controller-manager/cmd/agent/main.go
@@ -307,6 +307,12 @@ func mainFunc() error {
 		for _, disk := range disks {
 			func(path string) {
 				eg.Go(func() error {
+					if disk.ReadOnly {
+						log.Printf("Skipping read-only disk %s", path)
+
+						return nil
+					}
+
 					log.Printf("Resetting %s", path)
 
 					bd, err := blockdevice.Open(path)

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pin/tftp v2.1.1-0.20200117065540-2f79be2dba4e+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.1
-	github.com/talos-systems/go-blockdevice v0.3.1
+	github.com/talos-systems/go-blockdevice v0.3.4
 	github.com/talos-systems/go-debug v0.2.1
 	github.com/talos-systems/go-kmsg v0.1.1
 	github.com/talos-systems/go-procfs v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -695,8 +695,9 @@ github.com/talos-systems/crypto v0.3.4/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOG
 github.com/talos-systems/crypto v0.3.5 h1:Jkxjzx/IfOvisjDAAoe7QaHySZ5+8v1xWOJ0o0GhtQI=
 github.com/talos-systems/crypto v0.3.5/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOGBBMj58MrIPY8=
 github.com/talos-systems/go-blockdevice v0.2.4/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
-github.com/talos-systems/go-blockdevice v0.3.1 h1:DpewOhlvxNmt+PXOFmOZ2AO9TzeNVSScSQAhpY0c+6Q=
 github.com/talos-systems/go-blockdevice v0.3.1/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
+github.com/talos-systems/go-blockdevice v0.3.4 h1:LP2hgIcd5qbympxYFlWbHYTPyD/f/sZjBMma01soniQ=
+github.com/talos-systems/go-blockdevice v0.3.4/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-debug v0.2.1 h1:VSN8P1zXWeHWgUBZn4cVT3keBcecCAJBG9Up+F6N2KM=
 github.com/talos-systems/go-debug v0.2.1/go.mod h1:pR4NjsZQNFqGx3n4qkD4MIj1F2CxyIF8DCiO1+05JO0=

--- a/sfyra/go.mod
+++ b/sfyra/go.mod
@@ -140,7 +140,7 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/talos-systems/cluster-api-bootstrap-provider-talos v0.5.3 // indirect
 	github.com/talos-systems/crypto v0.3.5 // indirect
-	github.com/talos-systems/go-blockdevice v0.3.1 // indirect
+	github.com/talos-systems/go-blockdevice v0.3.4 // indirect
 	github.com/talos-systems/go-cmd v0.1.0 // indirect
 	github.com/u-root/uio v0.0.0-20210528114334-82958018845c // indirect
 	github.com/ulikunitz/xz v0.5.8 // indirect

--- a/sfyra/go.sum
+++ b/sfyra/go.sum
@@ -1222,8 +1222,9 @@ github.com/talos-systems/crypto v0.3.5/go.mod h1:xaNCB2/Bxaj+qrkdeodhRv5eKQVvKOG
 github.com/talos-systems/discovery-api v0.1.0/go.mod h1:ZsbzzOC5bzToaF3+YvUXDf9paeWV5bedpDu5RPXrglM=
 github.com/talos-systems/discovery-client v0.1.0/go.mod h1:LxqCv16VBB68MgaMnV8jXujYd3Q097DAn22U5gaHmkU=
 github.com/talos-systems/go-blockdevice v0.2.4/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
-github.com/talos-systems/go-blockdevice v0.3.1 h1:DpewOhlvxNmt+PXOFmOZ2AO9TzeNVSScSQAhpY0c+6Q=
 github.com/talos-systems/go-blockdevice v0.3.1/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
+github.com/talos-systems/go-blockdevice v0.3.4 h1:LP2hgIcd5qbympxYFlWbHYTPyD/f/sZjBMma01soniQ=
+github.com/talos-systems/go-blockdevice v0.3.4/go.mod h1:qnn/zDc09I1DA2BUDDCOSA2D0P8pIDjN8pGiRoRaQig=
 github.com/talos-systems/go-cmd v0.0.0-20210216164758-68eb0067e0f0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=
 github.com/talos-systems/go-cmd v0.1.0 h1:bqPeL0ksproFyTOlvMisdUXc7uAf0aqJ5Q6waSGv32s=
 github.com/talos-systems/go-cmd v0.1.0/go.mod h1:kf+rZzTEmlDiYQ6ulslvRONnKLQH8x83TowltGMhO+k=


### PR DESCRIPTION
This brings new blockdevice library with read-only bd detection.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>