### PR TITLE
docs: handle latest version banner and canonical urls

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "cd website && hugo --gc --minify"
+command = "cd website && hugo --gc --minify --baseURL $DEPLOY_PRIME_URL"
 publish = "website/public"
 
 [build.environment]

--- a/website/assets/scss/_styles_project.scss
+++ b/website/assets/scss/_styles_project.scss
@@ -1,0 +1,5 @@
+.version-banner {
+    position: sticky;
+    top: 5rem;
+    z-index: 1;
+}

--- a/website/layouts/partials/doc_latest_version.html
+++ b/website/layouts/partials/doc_latest_version.html
@@ -1,0 +1,10 @@
+{{ $page := .Site.Params.url_latest_version }}
+{{ $doc_latest_version := replaceRE (.Section | printf "^/%s") .Site.Params.url_latest_version .Page.RelPermalink | path.Clean }}
+{{ range $p := (where .Site.Pages "Section" (.Site.Params.url_latest_version | strings.TrimPrefix "/")) }}
+{{ $page = cond (eq $doc_latest_version ($p.RelPermalink | path.Clean)) $p.RelPermalink $page }}
+{{ range .Aliases }}
+{{ $alias := cond (hasPrefix . "/") . (path.Join $p.RelPermalink ".." .) }}
+{{ $page = cond (eq $alias $doc_latest_version) $p.RelPermalink $page}}
+{{ end }}
+{{ end }}
+{{ return $page }}

--- a/website/layouts/partials/hooks/head-end.html
+++ b/website/layouts/partials/hooks/head-end.html
@@ -5,3 +5,15 @@
 {{ if (findRE "<pre" .Content 1) }}
     <link rel="stylesheet" href="/css/clipboard.css">
 {{ end }}
+
+<!--- https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls?hl=en#rel-canonical-link-method -->
+{{ if .Section }}
+  {{ $latest_version := .Site.Params.url_latest_version }}
+  {{ $current_version := .Section | printf "/%s" }}
+  {{ if ne $latest_version $current_version }}
+    {{ $latest_doc := partial "doc_latest_version.html" . }}
+    {{ if ne $latest_doc $latest_version }}
+      <link rel="canonical" href="{{ $latest_doc | safeURL | absURL }}" />
+    {{ end }}
+  {{ end }}
+{{ end }}

--- a/website/layouts/partials/version-banner.html
+++ b/website/layouts/partials/version-banner.html
@@ -2,25 +2,26 @@
   If yes, display a banner. -->
 {{ $latest_version := .Site.Params.url_latest_version }}
 {{ $current_version := .Section | printf "/%s" }}
+{{ $latest_doc := partial "doc_latest_version.html" . }}
 
 {{ if .FirstSection.Params.prerelease }}
-  {{ $color := "primary" }}
-  <div class="pageinfo pageinfo-{{ $color }}">
+  {{ $color := "info" }}
+  <div class="version-banner pageinfo pageinfo-{{ $color }}">
     {{ with $current_version }}<p>Version {{ trim . "/" | markdownify }} of the
-      documentation is for the Sidero version being developed.
-      {{ with $latest_version }}For the latest stable version of Sidero, see the
-        <a href="{{ $latest_version | safeURL }}">latest version</a>.</p>
+      documentation is for the Sidero Metal version being developed.
+      {{ with $latest_version }}For the latest stable version of Sidero Metal, see the
+        <a href="{{ $latest_doc | safeURL }}">latest version</a>.</p>
       {{ end }}
     {{ end }}
   </div>
 {{ else if ne $latest_version $current_version }}
-  {{ $color := "primary" }}
-  <div class="pageinfo pageinfo-{{ $color }}">
+  {{ $color := "warning" }}
+  <div class="version-banner pageinfo pageinfo-{{ $color }}">
     {{ with $current_version }}<p>Version {{ trim . "/" | markdownify }} of the
       documentation is no longer actively maintained. The site that you are
       currently viewing is an archived snapshot.
       {{ with $latest_version }}For up-to-date documentation, see the
-        <a href="{{ $latest_version | safeURL }}">latest version</a>.</p>
+        <a href="{{ $latest_doc | safeURL }}">latest version</a>.</p>
       {{ end }}
     {{ end }}
   </div>


### PR DESCRIPTION
This PR is a copy of two PRs from talos:

https://github.com/siderolabs/talos/pull/5389/files
https://github.com/siderolabs/talos/pull/5391/files

It ensures that the banner is shown if the user isn't viewing the latest sidero docs. This actually already was working but the banner html was in an incorrect spot, so moved that to match what's seen in Talos repo. Also adds the canonical links for search engines to update their indexes.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>