### PR TITLE
fix: properly inspect readonly flag of the disk

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -194,7 +194,7 @@ services:
     commands:
     - --dns=8.8.8.8
     - --dns=8.8.4.4
-    - --mtu=1500
+    - --mtu=1450
     - --log-level=error
     privileged: true
     volumes:
@@ -240,6 +240,6 @@ depends_on:
   - default
 ---
 kind: signature
-hmac: be731588cd395016c6bf2c73f6266d491916a5e41a5fc2745e77aa99d1e014c2
+hmac: 6425fcd833ae7569c74776f815d8c5be3e3df1fca97908cb2bccf38dcb3f04af
 
 ...

--- a/app/sidero-controller-manager/cmd/agent/main.go
+++ b/app/sidero-controller-manager/cmd/agent/main.go
@@ -304,9 +304,11 @@ func mainFunc() error {
 			wg.Wait()
 		}()
 
-		for _, disk := range disks {
-			func(path string) {
+		for _, d := range disks {
+			func(disk *disk.Disk) {
 				eg.Go(func() error {
+					path := disk.DeviceName
+
 					if disk.ReadOnly {
 						log.Printf("Skipping read-only disk %s", path)
 
@@ -339,7 +341,7 @@ func mainFunc() error {
 
 					return bd.Close()
 				})
-			}(disk.DeviceName)
+			}(d)
 		}
 
 		if err := eg.Wait(); err != nil {

--- a/sfyra/pkg/constants/constants.go
+++ b/sfyra/pkg/constants/constants.go
@@ -11,7 +11,7 @@ import "net"
 var Nameservers = []net.IP{net.ParseIP("8.8.8.8"), net.ParseIP("1.1.1.1")}
 
 // MTU default setting.
-const MTU = 1500
+const MTU = 1440
 
 // BootstrapMaster is a bootstrap cluster master node name.
 const BootstrapMaster = "bootstrap-master"


### PR DESCRIPTION
This is classic Go bug with using variable of a for loop in a closure :(

This leads to random disks being skipped/not-skipped as readonly on disk
wiping.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>