### PR TITLE
fix: canonical links in docs site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-command = "cd website && hugo --gc --minify --baseURL $DEPLOY_PRIME_URL"
+command = "hugo --source website --gc --minify"
 publish = "website/public"
 
 [build.environment]

--- a/website/layouts/partials/hooks/head-end.html
+++ b/website/layouts/partials/hooks/head-end.html
@@ -13,7 +13,7 @@
   {{ if ne $latest_version $current_version }}
     {{ $latest_doc := partial "doc_latest_version.html" . }}
     {{ if ne $latest_doc $latest_version }}
-      <link rel="canonical" href="{{ $latest_doc | safeURL | absURL }}" />
+      <link rel="canonical" href="https://www.sidero.dev{{ $latest_doc | absURL }}" />
     {{ end }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Fixes canonical link for the documentation website.

Signed-off-by: Tim Jones <tim.jones@siderolabs.com>