### PR TITLE
fix: docs: /etc/dhcp -> config to preserve across firmware update

### DIFF
--- a/website/content/v0.1/Guides/bootstrapping.md
+++ b/website/content/v0.1/Guides/bootstrapping.md
@@ -47,14 +47,14 @@ $ show service dhcp-server shared-network-name MetalDHCP
      start 192.168.254.2 {
          stop 192.168.254.252
      }
-     subnet-parameters "include &quot;/etc/dhcp/ipxe-metal.conf&quot;;"
+     subnet-parameters "include &quot;/config/ipxe-metal.conf&quot;;"
  }
 ```
 
 Here is the ipxe-metal.conf file.
 
 ```bash
-$ cat /etc/dhcp/ipxe-metal.conf
+$ cat /config/ipxe-metal.conf
 
 allow bootp;
 allow booting;

--- a/website/content/v0.2/Getting Started/prereq-dhcp.md
+++ b/website/content/v0.2/Getting Started/prereq-dhcp.md
@@ -105,7 +105,7 @@ shared-network sidero {
   subnet 172.16.199.0 netmask 255.255.255.0 {
     option domain-name-servers 8.8.8.8, 1.1.1.1;
     option routers 172.16.199.1;
-    include "/etc/dhcp/ipxe-metal.conf";
+    include "/config/ipxe-metal.conf";
   }
 }
 ```

--- a/website/content/v0.2/Guides/bootstrapping.md
+++ b/website/content/v0.2/Guides/bootstrapping.md
@@ -47,14 +47,14 @@ $ show service dhcp-server shared-network-name MetalDHCP
      start 192.168.254.2 {
          stop 192.168.254.252
      }
-     subnet-parameters "include &quot;/etc/dhcp/ipxe-metal.conf&quot;;"
+     subnet-parameters "include &quot;/config/ipxe-metal.conf&quot;;"
  }
 ```
 
 Here is the ipxe-metal.conf file.
 
 ```bash
-$ cat /etc/dhcp/ipxe-metal.conf
+$ cat /config/ipxe-metal.conf
 
 allow bootp;
 allow booting;

--- a/website/content/v0.3/Getting Started/prereq-dhcp.md
+++ b/website/content/v0.3/Getting Started/prereq-dhcp.md
@@ -105,7 +105,7 @@ shared-network sidero {
   subnet 172.16.199.0 netmask 255.255.255.0 {
     option domain-name-servers 8.8.8.8, 1.1.1.1;
     option routers 172.16.199.1;
-    include "/etc/dhcp/ipxe-metal.conf";
+    include "/config/ipxe-metal.conf";
   }
 }
 ```

--- a/website/content/v0.3/Guides/bootstrapping.md
+++ b/website/content/v0.3/Guides/bootstrapping.md
@@ -47,14 +47,14 @@ $ show service dhcp-server shared-network-name MetalDHCP
      start 192.168.254.2 {
          stop 192.168.254.252
      }
-     subnet-parameters "include &quot;/etc/dhcp/ipxe-metal.conf&quot;;"
+     subnet-parameters "include &quot;/config/ipxe-metal.conf&quot;;"
  }
 ```
 
 Here is the ipxe-metal.conf file.
 
 ```bash
-$ cat /etc/dhcp/ipxe-metal.conf
+$ cat /config/ipxe-metal.conf
 
 allow bootp;
 allow booting;

--- a/website/content/v0.4/Getting Started/prereq-dhcp.md
+++ b/website/content/v0.4/Getting Started/prereq-dhcp.md
@@ -105,7 +105,7 @@ shared-network sidero {
   subnet 172.16.199.0 netmask 255.255.255.0 {
     option domain-name-servers 8.8.8.8, 1.1.1.1;
     option routers 172.16.199.1;
-    include "/etc/dhcp/ipxe-metal.conf";
+    include "/config/ipxe-metal.conf";
   }
 }
 ```
@@ -121,7 +121,7 @@ Ubiquiti EdgeRouter configuration statement:
 ```text
 set service dhcp-server shared-network-name sidero \
   subnet 172.16.199.1 \
-  subnet-parameters "include &quot;/etc/dhcp/ipxe-metal.conf&quot;;"
+  subnet-parameters "include &quot;/config/ipxe-metal.conf&quot;;"
 ```
 
 Also note the fact that there are two semicolons at the end of the line.

--- a/website/content/v0.4/Guides/bootstrapping.md
+++ b/website/content/v0.4/Guides/bootstrapping.md
@@ -49,14 +49,14 @@ $ show service dhcp-server shared-network-name MetalDHCP
      start 192.168.254.2 {
          stop 192.168.254.252
      }
-     subnet-parameters "include &quot;/etc/dhcp/ipxe-metal.conf&quot;;"
+     subnet-parameters "include &quot;/config/ipxe-metal.conf&quot;;"
  }
 ```
 
 Here is the `ipxe-metal.conf` file.
 
 ```bash
-$ cat /etc/dhcp/ipxe-metal.conf
+$ cat /config/ipxe-metal.conf
 
 allow bootp;
 allow booting;
@@ -81,7 +81,7 @@ set service dhcp-server global-parameters "option system-arch code 93 = unsigned
 Now we can specify condition based on *option 93* in `ipxe-metal.conf` file
 
 ```bash
-$ cat /etc/dhcp/ipxe-metal.conf
+$ cat /config/ipxe-metal.conf
 
 allow bootp;
 allow booting;

--- a/website/content/v0.5/Getting Started/prereq-dhcp.md
+++ b/website/content/v0.5/Getting Started/prereq-dhcp.md
@@ -109,7 +109,7 @@ shared-network sidero {
   subnet 172.16.199.0 netmask 255.255.255.0 {
     option domain-name-servers 8.8.8.8, 1.1.1.1;
     option routers 172.16.199.1;
-    include "/etc/dhcp/ipxe-metal.conf";
+    include "/config/ipxe-metal.conf";
   }
 }
 ```
@@ -125,7 +125,7 @@ Ubiquiti EdgeRouter configuration statement:
 ```text
 set service dhcp-server shared-network-name sidero \
   subnet 172.16.199.1 \
-  subnet-parameters "include &quot;/etc/dhcp/ipxe-metal.conf&quot;;"
+  subnet-parameters "include &quot;/config/ipxe-metal.conf&quot;;"
 ```
 
 Also note the fact that there are two semicolons at the end of the line.

--- a/website/content/v0.5/Guides/bootstrapping.md
+++ b/website/content/v0.5/Guides/bootstrapping.md
@@ -49,14 +49,14 @@ $ show service dhcp-server shared-network-name MetalDHCP
      start 192.168.254.2 {
          stop 192.168.254.252
      }
-     subnet-parameters "include &quot;/etc/dhcp/ipxe-metal.conf&quot;;"
+     subnet-parameters "include &quot;/config/ipxe-metal.conf&quot;;"
  }
 ```
 
 Here is the `ipxe-metal.conf` file.
 
 ```bash
-$ cat /etc/dhcp/ipxe-metal.conf
+$ cat /config/ipxe-metal.conf
 
 allow bootp;
 allow booting;
@@ -81,7 +81,7 @@ set service dhcp-server global-parameters "option system-arch code 93 = unsigned
 Now we can specify condition based on *option 93* in `ipxe-metal.conf` file
 
 ```bash
-$ cat /etc/dhcp/ipxe-metal.conf
+$ cat /config/ipxe-metal.conf
 
 allow bootp;
 allow booting;

--- a/website/content/v0.6/Getting Started/prereq-dhcp.md
+++ b/website/content/v0.6/Getting Started/prereq-dhcp.md
@@ -102,7 +102,7 @@ shared-network sidero {
   subnet 172.16.199.0 netmask 255.255.255.0 {
     option domain-name-servers 8.8.8.8, 1.1.1.1;
     option routers 172.16.199.1;
-    include "/etc/dhcp/ipxe-metal.conf";
+    include "/config/ipxe-metal.conf";
   }
 }
 ```
@@ -118,7 +118,7 @@ Ubiquiti EdgeRouter configuration statement:
 ```text
 set service dhcp-server shared-network-name sidero \
   subnet 172.16.199.1 \
-  subnet-parameters "include &quot;/etc/dhcp/ipxe-metal.conf&quot;;"
+  subnet-parameters "include &quot;/config/ipxe-metal.conf&quot;;"
 ```
 
 Also note the fact that there are two semicolons at the end of the line.

--- a/website/content/v0.6/Guides/bootstrapping.md
+++ b/website/content/v0.6/Guides/bootstrapping.md
@@ -49,14 +49,14 @@ $ show service dhcp-server shared-network-name MetalDHCP
      start 192.168.254.2 {
          stop 192.168.254.252
      }
-     subnet-parameters "include &quot;/etc/dhcp/ipxe-metal.conf&quot;;"
+     subnet-parameters "include &quot;/config/ipxe-metal.conf&quot;;"
  }
 ```
 
 Here is the `ipxe-metal.conf` file.
 
 ```bash
-$ cat /etc/dhcp/ipxe-metal.conf
+$ cat /config/ipxe-metal.conf
 
 allow bootp;
 allow booting;
@@ -81,7 +81,7 @@ set service dhcp-server global-parameters "option system-arch code 93 = unsigned
 Now we can specify condition based on *option 93* in `ipxe-metal.conf` file
 
 ```bash
-$ cat /etc/dhcp/ipxe-metal.conf
+$ cat /config/ipxe-metal.conf
 
 allow bootp;
 allow booting;


### PR DESCRIPTION
The docs currently suggest placing the ipxe configuration file in /etc/dhcp/ - while this seems sane, when you update the firmware of an EdgeOS Device, which this is geared towards (or any other vyatta-based device), the entire filesystem is wiped, other than the /config directory.

This becomes especially problematic, because the config itself will still reference this file, and the dhcp server will refuse to start. From /var/log/messsages:

```
Oct 29 00:17:03 ubnt systemd[1]: vyatta-dhcpd.service: Control process exited, code=exited status=1
Oct 29 00:17:03 ubnt systemd[1]: Failed to start EdgeOS DHCP Server.
Oct 29 00:17:03 ubnt systemd[1]: vyatta-dhcpd.service: Unit entered failed state.
Oct 29 00:17:03 ubnt systemd[1]: vyatta-dhcpd.service: Failed with result 'exit-code'.
Oct 29 00:17:05 ubnt dhcpd3: Can't open /etc/dhcp/ipxe-metal.conf: No such file or directory
Oct 29 00:17:05 ubnt dhcpd3:
Oct 29 00:17:05 ubnt dhcpd3: If you did not get this software from ftp.isc.org, please
Oct 29 00:17:05 ubnt dhcpd3: get the latest from ftp.isc.org and install that before
Oct 29 00:17:05 ubnt dhcpd3: requesting help.
Oct 29 00:17:05 ubnt dhcpd3:
Oct 29 00:17:05 ubnt dhcpd3: If you did get this software from ftp.isc.org and have not
Oct 29 00:17:05 ubnt dhcpd3: yet read the README, please read it before requesting help.
Oct 29 00:17:05 ubnt dhcpd3: If you intend to request help from the dhcp-bugs at isc.org
Oct 29 00:17:05 ubnt dhcpd3: mailing list, please read the section on the README about
Oct 29 00:17:05 ubnt dhcpd3: submitting bug reports and requests for help.
Oct 29 00:17:05 ubnt dhcpd3:
Oct 29 00:17:05 ubnt dhcpd3: Please do not under any circumstances send requests for
Oct 29 00:17:05 ubnt dhcpd3: help directly to the authors of this software - please
Oct 29 00:17:05 ubnt dhcpd3: send them to the appropriate mailing list as described in
Oct 29 00:17:05 ubnt dhcpd3: the README file.
Oct 29 00:17:05 ubnt dhcpd3:
Oct 29 00:17:05 ubnt dhcpd3: exiting.
```

**To fix this, any files which are referenced in the EdgeOS config need to be stored in the /config directory. Updating the docs to fix this reference, so others don't get bitten by this.**

Signed-off-by: Russell Troxel <russell@troxel.io>