### PR TITLE
feat: provide a way to override IPMI PXE boot method on `Server`

### DIFF
--- a/app/sidero-controller-manager/api/v1alpha1/server_types.go
+++ b/app/sidero-controller-manager/api/v1alpha1/server_types.go
@@ -164,6 +164,13 @@ type ServerSpec struct {
 	//
 	// +optional
 	BootFromDiskMethod siderotypes.BootFromDisk `json:"bootFromDiskMethod,omitempty"`
+	// PXEMode specifies the method to trigger PXE boot via IPMI.
+	//
+	// If not set, controller default is used.
+	// Valid values: uefi, bios.
+	//
+	// +optional
+	PXEMode siderotypes.PXEMode `json:"pxeMode,omitempty"`
 }
 
 const (

--- a/app/sidero-controller-manager/api/v1alpha1/zz_generated.conversion.go
+++ b/app/sidero-controller-manager/api/v1alpha1/zz_generated.conversion.go
@@ -812,6 +812,7 @@ func autoConvert_v1alpha1_ServerSpec_To_v1alpha2_ServerSpec(in *ServerSpec, out 
 	out.Cordoned = in.Cordoned
 	out.PXEBootAlways = in.PXEBootAlways
 	out.BootFromDiskMethod = types.BootFromDisk(in.BootFromDiskMethod)
+	out.PXEMode = types.PXEMode(in.PXEMode)
 	return nil
 }
 
@@ -826,6 +827,7 @@ func autoConvert_v1alpha2_ServerSpec_To_v1alpha1_ServerSpec(in *v1alpha2.ServerS
 	out.Cordoned = in.Cordoned
 	out.PXEBootAlways = in.PXEBootAlways
 	out.BootFromDiskMethod = types.BootFromDisk(in.BootFromDiskMethod)
+	out.PXEMode = types.PXEMode(in.PXEMode)
 	return nil
 }
 

--- a/app/sidero-controller-manager/api/v1alpha2/server_types.go
+++ b/app/sidero-controller-manager/api/v1alpha2/server_types.go
@@ -252,6 +252,13 @@ type ServerSpec struct {
 	//
 	// +optional
 	BootFromDiskMethod siderotypes.BootFromDisk `json:"bootFromDiskMethod,omitempty"`
+	// PXEMode specifies the method to trigger PXE boot via IPMI.
+	//
+	// If not set, controller default is used.
+	// Valid values: uefi, bios.
+	//
+	// +optional
+	PXEMode siderotypes.PXEMode `json:"pxeMode,omitempty"`
 }
 
 const (

--- a/app/sidero-controller-manager/api/v1alpha2/server_webhook.go
+++ b/app/sidero-controller-manager/api/v1alpha2/server_webhook.go
@@ -63,6 +63,20 @@ func (r *Server) ValidateDelete() error {
 func (r *Server) validate() error {
 	var allErrs field.ErrorList
 
+	allErrs = append(allErrs, r.validateBootFromDisk()...)
+	allErrs = append(allErrs, r.validatePXEMode()...)
+	allErrs = append(allErrs, r.validateConfigPatches()...)
+
+	if len(allErrs) == 0 {
+		return nil
+	}
+
+	return apierrors.NewInvalid(
+		schema.GroupKind{Group: GroupVersion.Group, Kind: "Server"},
+		r.Name, allErrs)
+}
+
+func (r *Server) validateBootFromDisk() (allErrs field.ErrorList) {
 	validValues := []siderotypes.BootFromDisk{
 		"",
 		siderotypes.BootIPXEExit,
@@ -88,6 +102,38 @@ func (r *Server) validate() error {
 		)
 	}
 
+	return allErrs
+}
+
+func (r *Server) validatePXEMode() (allErrs field.ErrorList) {
+	validValues := []siderotypes.PXEMode{
+		"",
+		siderotypes.PXEModeBIOS,
+		siderotypes.PXEModeUEFI,
+	}
+
+	var valid bool
+
+	for _, v := range validValues {
+		if r.Spec.PXEMode == v {
+			valid = true
+
+			break
+		}
+	}
+
+	if !valid {
+		allErrs = append(allErrs,
+			field.Invalid(field.NewPath("spec").Child("pxeMode"), r.Spec.BootFromDiskMethod,
+				fmt.Sprintf("valid values are: %q", validValues),
+			),
+		)
+	}
+
+	return allErrs
+}
+
+func (r *Server) validateConfigPatches() (allErrs field.ErrorList) {
 	for index, patch := range r.Spec.ConfigPatches {
 		if _, ok := operations[patch.Op]; !ok {
 			allErrs = append(allErrs,
@@ -98,13 +144,7 @@ func (r *Server) validate() error {
 		}
 	}
 
-	if len(allErrs) == 0 {
-		return nil
-	}
-
-	return apierrors.NewInvalid(
-		schema.GroupKind{Group: GroupVersion.Group, Kind: "Server"},
-		r.Name, allErrs)
+	return allErrs
 }
 
 func init() {

--- a/app/sidero-controller-manager/config/crd/bases/metal.sidero.dev_servers.yaml
+++ b/app/sidero-controller-manager/config/crd/bases/metal.sidero.dev_servers.yaml
@@ -241,6 +241,11 @@ spec:
                 type: object
               pxeBootAlways:
                 type: boolean
+              pxeMode:
+                description: "PXEMode specifies the method to trigger PXE boot via
+                  IPMI. \n If not set, controller default is used. Valid values: uefi,
+                  bios."
+                type: string
               system:
                 properties:
                   family:
@@ -702,6 +707,11 @@ spec:
                 type: object
               pxeBootAlways:
                 type: boolean
+              pxeMode:
+                description: "PXEMode specifies the method to trigger PXE boot via
+                  IPMI. \n If not set, controller default is used. Valid values: uefi,
+                  bios."
+                type: string
             required:
             - accepted
             type: object

--- a/app/sidero-controller-manager/internal/power/api/api.go
+++ b/app/sidero-controller-manager/internal/power/api/api.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha2"
-	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/power/metal"
+	"github.com/talos-systems/sidero/app/sidero-controller-manager/pkg/types"
 )
 
 // Client provides management over simple API.
@@ -88,7 +88,7 @@ func (c *Client) PowerCycle() error {
 }
 
 // SetPXE makes sure the node will pxe boot next time.
-func (c *Client) SetPXE(mode metal.PXEMode) error {
+func (c *Client) SetPXE(mode types.PXEMode) error {
 	// no way to enforce mode via QEMU API
 	return c.postRequest("/pxeboot")
 }

--- a/app/sidero-controller-manager/internal/power/fake.go
+++ b/app/sidero-controller-manager/internal/power/fake.go
@@ -4,7 +4,7 @@
 
 package power
 
-import "github.com/talos-systems/sidero/app/sidero-controller-manager/internal/power/metal"
+import "github.com/talos-systems/sidero/app/sidero-controller-manager/pkg/types"
 
 type fakeClient struct{}
 
@@ -20,7 +20,7 @@ func (fakeClient) PowerCycle() error {
 	return nil
 }
 
-func (fakeClient) SetPXE(mode metal.PXEMode) error {
+func (fakeClient) SetPXE(mode types.PXEMode) error {
 	return nil
 }
 

--- a/app/sidero-controller-manager/internal/power/ipmi/ipmi.go
+++ b/app/sidero-controller-manager/internal/power/ipmi/ipmi.go
@@ -10,7 +10,7 @@ import (
 	goipmi "github.com/pensando/goipmi"
 
 	metalv1 "github.com/talos-systems/sidero/app/sidero-controller-manager/api/v1alpha2"
-	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/power/metal"
+	"github.com/talos-systems/sidero/app/sidero-controller-manager/pkg/types"
 )
 
 // Link to the IPMI spec: https://www.intel.com/content/dam/www/public/us/en/documents/product-briefs/ipmi-second-gen-interface-spec-v2-rev1-1.pdf
@@ -93,11 +93,11 @@ func (c *Client) Status() (*goipmi.ChassisStatusResponse, error) {
 }
 
 // SetPXE makes sure the node will pxe boot next time.
-func (c *Client) SetPXE(mode metal.PXEMode) error {
+func (c *Client) SetPXE(mode types.PXEMode) error {
 	switch mode {
-	case metal.PXEModeBIOS:
+	case types.PXEModeBIOS:
 		return c.IPMIClient.SetBootDevice(goipmi.BootDevicePxe)
-	case metal.PXEModeUEFI:
+	case types.PXEModeUEFI:
 		return c.IPMIClient.SetBootDeviceEFI(goipmi.BootDevicePxe)
 	default:
 		return fmt.Errorf("unsupported mode %q", mode)

--- a/app/sidero-controller-manager/internal/power/metal/metal.go
+++ b/app/sidero-controller-manager/internal/power/metal/metal.go
@@ -5,32 +5,15 @@
 // Package metal provides interfaces to manage metal machines.
 package metal
 
+import "github.com/talos-systems/sidero/app/sidero-controller-manager/pkg/types"
+
 // ManagementClient control power and boot order of metal machine.
 type ManagementClient interface {
 	PowerOn() error
 	PowerOff() error
 	PowerCycle() error
 	IsPoweredOn() (bool, error)
-	SetPXE(mode PXEMode) error
+	SetPXE(mode types.PXEMode) error
 	IsFake() bool
 	Close() error
-}
-
-// PXEMode specifies PXE boot mode.
-type PXEMode string
-
-const (
-	PXEModeBIOS = "bios"
-	PXEModeUEFI = "uefi"
-)
-
-func (mode PXEMode) IsValid() bool {
-	switch mode {
-	case PXEModeBIOS:
-		return true
-	case PXEModeUEFI:
-		return true
-	default:
-		return false
-	}
 }

--- a/app/sidero-controller-manager/main.go
+++ b/app/sidero-controller-manager/main.go
@@ -37,7 +37,6 @@ import (
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/ipxe"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/metadata"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/power/api"
-	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/power/metal"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/server"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/siderolink"
 	"github.com/talos-systems/sidero/app/sidero-controller-manager/internal/tftp"
@@ -103,7 +102,7 @@ func main() {
 	flag.BoolVar(&insecureWipe, "insecure-wipe", true, "Wipe head of the disk only (if false, wipe whole disk).")
 	flag.BoolVar(&autoBMCSetup, "auto-bmc-setup", true, "Attempt to setup BMC info automatically when agent boots.")
 	flag.DurationVar(&serverRebootTimeout, "server-reboot-timeout", constants.DefaultServerRebootTimeout, "Timeout to wait for the server to restart and start wipe.")
-	flag.StringVar(&ipmiPXEMethod, "ipmi-pxe-method", string(metal.PXEModeUEFI), fmt.Sprintf("Default method to use to set server to boot from PXE via IPMI: %s.", []string{metal.PXEModeUEFI, metal.PXEModeBIOS}))
+	flag.StringVar(&ipmiPXEMethod, "ipmi-pxe-method", string(siderotypes.PXEModeUEFI), fmt.Sprintf("Default method to use to set server to boot from PXE via IPMI: %s.", []string{siderotypes.PXEModeUEFI, siderotypes.PXEModeBIOS}))
 	flag.Float64Var(&testPowerSimulatedExplicitFailureProb, "test-power-simulated-explicit-failure-prob", 0, "Test failure simulation setting.")
 	flag.Float64Var(&testPowerSimulatedSilentFailureProb, "test-power-simulated-silent-failure-prob", 0, "Test failure simulation setting.")
 
@@ -132,7 +131,7 @@ func main() {
 		}
 	}
 
-	if !metal.PXEMode(ipmiPXEMethod).IsValid() {
+	if !siderotypes.PXEMode(ipmiPXEMethod).IsValid() {
 		setupLog.Error(fmt.Errorf("ipmi-pxe-method is invalid"), "")
 		os.Exit(1)
 	}
@@ -204,7 +203,7 @@ func main() {
 		APIReader:     mgr.GetAPIReader(),
 		Recorder:      recorder,
 		RebootTimeout: serverRebootTimeout,
-		PXEMode:       metal.PXEMode(ipmiPXEMethod),
+		PXEMode:       siderotypes.PXEMode(ipmiPXEMethod),
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: defaultMaxConcurrentReconciles}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Server")
 		os.Exit(1)

--- a/app/sidero-controller-manager/pkg/types/types.go
+++ b/app/sidero-controller-manager/pkg/types/types.go
@@ -12,3 +12,22 @@ const (
 	Boot404      BootFromDisk = "http-404"     // Return HTTP 404 response to iPXE.
 	BootSANDisk  BootFromDisk = "ipxe-sanboot" // Use iPXE script with `sanboot` command.
 )
+
+// PXEMode specifies PXE boot mode.
+type PXEMode string
+
+const (
+	PXEModeBIOS = "bios"
+	PXEModeUEFI = "uefi"
+)
+
+func (mode PXEMode) IsValid() bool {
+	switch mode {
+	case PXEModeBIOS:
+		return true
+	case PXEModeUEFI:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
This adds a new field to the `Server` resource which can be used to override default IPMI PXE boot method.

Fixes #987

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>