### PR TITLE
docs: remove non-inclusive Kubernetes terms from 0.5 & 0.6 website docs

### DIFF
--- a/website/content/v0.5/Getting Started/prereq-kubernetes.md
+++ b/website/content/v0.5/Getting Started/prereq-kubernetes.md
@@ -37,7 +37,7 @@ talosctl cluster create \
   --name sidero-demo \
   -p 69:69/udp,8081:8081/tcp,51821:51821/udp \
   --workers 0 \
-  --config-patch '[{"op": "add", "path": "/cluster/allowSchedulingOnMasters", "value": true}]' \
+  --config-patch '[{"op": "add", "path": "/cluster/allowSchedulingOnControlPlanes", "value": true}]' \
   --endpoint $HOST_IP
 ```
 

--- a/website/content/v0.5/Guides/bootstrapping.md
+++ b/website/content/v0.5/Guides/bootstrapping.md
@@ -138,7 +138,7 @@ You should then set your `KUBECONFIG` environment variable to the path of this f
 Because this is a single node cluster, we need to remove the "NoSchedule" taint on the node to make sure non-controlplane components can be scheduled.
 
 ```bash
-kubectl taint node talos-default-master-1 node-role.kubernetes.io/master:NoSchedule-
+kubectl taint node talos-default-controlplane-1 node-role.kubernetes.io/control-plane:NoSchedule-
 ```
 
 ## Install Sidero

--- a/website/content/v0.5/Guides/sidero-on-rpi4.md
+++ b/website/content/v0.5/Guides/sidero-on-rpi4.md
@@ -30,7 +30,7 @@ export SIDERO_ENDPOINT=192.168.x.x
 Generate Talos machine configuration for a single-node cluster:
 
 ```bash
-talosctl gen config --config-patch='[{"op": "add", "path": "/cluster/allowSchedulingOnMasters", "value": true},{"op": "replace", "path": "/machine/install/disk", "value": "/dev/mmcblk0"}]' rpi4-sidero https://${SIDERO_ENDPOINT}:6443/
+talosctl gen config --config-patch='[{"op": "add", "path": "/cluster/allowSchedulingOnControlPlanes", "value": true},{"op": "replace", "path": "/machine/install/disk", "value": "/dev/mmcblk0"}]' rpi4-sidero https://${SIDERO_ENDPOINT}:6443/
 ```
 
 Submit the generated configuration to Talos:

--- a/website/content/v0.6/Getting Started/prereq-kubernetes.md
+++ b/website/content/v0.6/Getting Started/prereq-kubernetes.md
@@ -37,7 +37,7 @@ talosctl cluster create \
   --name sidero-demo \
   -p 69:69/udp,8081:8081/tcp,51821:51821/udp \
   --workers 0 \
-  --config-patch '[{"op": "add", "path": "/cluster/allowSchedulingOnMasters", "value": true}]' \
+  --config-patch '[{"op": "add", "path": "/cluster/allowSchedulingOnControlPlanes", "value": true}]' \
   --endpoint $HOST_IP
 ```
 

--- a/website/content/v0.6/Guides/bootstrapping.md
+++ b/website/content/v0.6/Guides/bootstrapping.md
@@ -138,7 +138,7 @@ You should then set your `KUBECONFIG` environment variable to the path of this f
 Because this is a single node cluster, we need to remove the "NoSchedule" taint on the node to make sure non-controlplane components can be scheduled.
 
 ```bash
-kubectl taint node talos-default-master-1 node-role.kubernetes.io/master:NoSchedule-
+kubectl taint node talos-default-control-plane-1 node-role.kubernetes.io/control-plane:NoSchedule-
 ```
 
 ## Install Sidero

--- a/website/content/v0.6/Guides/sidero-on-rpi4.md
+++ b/website/content/v0.6/Guides/sidero-on-rpi4.md
@@ -30,7 +30,7 @@ export SIDERO_ENDPOINT=192.168.x.x
 Generate Talos machine configuration for a single-node cluster:
 
 ```bash
-talosctl gen config --config-patch='[{"op": "add", "path": "/cluster/allowSchedulingOnMasters", "value": true},{"op": "replace", "path": "/machine/install/disk", "value": "/dev/mmcblk0"}]' rpi4-sidero https://${SIDERO_ENDPOINT}:6443/
+talosctl gen config --config-patch='[{"op": "add", "path": "/cluster/allowSchedulingOnControlPlanes", "value": true},{"op": "replace", "path": "/machine/install/disk", "value": "/dev/mmcblk0"}]' rpi4-sidero https://${SIDERO_ENDPOINT}:6443/
 ```
 
 Submit the generated configuration to Talos:


### PR DESCRIPTION
Remove non-inclusive Kubernetes terms from N and N+1 website docs