### PR TITLE
feat: provide 'snp.efi' and recommend it over 'ipxe.efi'

### DIFF
--- a/app/sidero-controller-manager/internal/ipxe/patch.go
+++ b/app/sidero-controller-manager/internal/ipxe/patch.go
@@ -19,12 +19,22 @@ import (
 // BIOS amd64 undionly.pxe is compressed, so we instead patch uncompressed version and compress it back using zbin.
 // (zbin is built with iPXE).
 func PatchBinaries(script []byte) error {
-	if err := patchScript("/var/lib/sidero/ipxe/amd64/ipxe.efi", "/var/lib/sidero/tftp/ipxe.efi", script); err != nil {
-		return err
-	}
+	for _, name := range []string{"ipxe", "snp"} {
+		if err := patchScript(
+			fmt.Sprintf("/var/lib/sidero/ipxe/amd64/%s.efi", name),
+			fmt.Sprintf("/var/lib/sidero/tftp/%s.efi", name),
+			script,
+		); err != nil {
+			return err
+		}
 
-	if err := patchScript("/var/lib/sidero/ipxe/arm64/ipxe.efi", "/var/lib/sidero/tftp/ipxe-arm64.efi", script); err != nil {
-		return err
+		if err := patchScript(
+			fmt.Sprintf("/var/lib/sidero/ipxe/arm64/%s.efi", name),
+			fmt.Sprintf("/var/lib/sidero/tftp/%s-arm64.efi", name),
+			script,
+		); err != nil {
+			return err
+		}
 	}
 
 	if err := patchScript("/var/lib/sidero/ipxe/amd64/kpxe/undionly.kpxe.bin", "/var/lib/sidero/ipxe/amd64/kpxe/undionly.kpxe.bin.patched", script); err != nil {

--- a/website/content/v0.6/Getting Started/expose-services.md
+++ b/website/content/v0.6/Getting Started/expose-services.md
@@ -33,7 +33,7 @@ It is a good idea to verify that the services are exposed as you think they
 should be.
 
 ```bash
-$ curl -I http://192.168.1.150:8081/tftp/ipxe.efi
+$ curl -I http://192.168.1.150:8081/tftp/snp.efi
 HTTP/1.1 200 OK
 Accept-Ranges: bytes
 Content-Length: 1020416

--- a/website/content/v0.6/Getting Started/troubleshooting.md
+++ b/website/content/v0.6/Getting Started/troubleshooting.md
@@ -57,7 +57,7 @@ TFTP service is available at the IP you are advertising via DHCP.
 
 ```bash
   $ atftp 172.16.199.50
-  tftp> get ipxe.efi
+  tftp> get snp.efi
 ```
 
 TFTP is an old, slow protocol with very little feedback or checking.

--- a/website/content/v0.6/Guides/bootstrapping.md
+++ b/website/content/v0.6/Guides/bootstrapping.md
@@ -62,7 +62,7 @@ allow bootp;
 allow booting;
 
 next-server 192.168.1.150;
-filename "ipxe.efi"; # use "undionly.kpxe" for BIOS netboot or "ipxe.efi" for UEFI netboot
+filename "snp.efi"; # use "undionly.kpxe" for BIOS netboot or "snp.efi" for UEFI netboot
 
 host talos-mgmt-0 {
     fixed-address 192.168.254.2;
@@ -89,9 +89,9 @@ allow booting;
 next-server 192.168.1.150;
 
 if option system-arch = 00:0b {
-    filename "ipxe-arm64.efi";
+    filename "snp-arm64.efi";
 } else {
-    filename "ipxe.efi";
+    filename "snp.efi";
 }
 
 host talos-mgmt-0 {

--- a/website/content/v0.6/Guides/first-cluster.md
+++ b/website/content/v0.6/Guides/first-cluster.md
@@ -63,9 +63,9 @@ if exists user-class and option user-class = "iPXE" {
     # UEFI
     if substring (option vendor-class-identifier, 0, 10) = "HTTPClient" {
       option vendor-class-identifier "HTTPClient";
-      filename "http://192.168.254.2:8081/tftp/ipxe.efi";
+      filename "http://192.168.254.2:8081/tftp/snp.efi";
     } else {
-      filename "ipxe.efi";
+      filename "snp.efi";
     }
   }
 }
@@ -79,7 +79,7 @@ host talos-mgmt-0 {
 There are multiple ways to boot the via iPXE:
 
 - if the node has built-in iPXE, direct URL to the iPXE script can be used: `http://192.168.254.2:8081/boot.ipxe`.
-- depending on the boot mode (BIOS or UEFI), either `ipxe.efi` or `undionly.kpxe` can be used (these images contain embedded iPXE scripts).
+- depending on the boot mode (BIOS or UEFI), either `snp.efi` or `undionly.kpxe` can be used (these images contain embedded iPXE scripts).
 - iPXE binaries can be delivered either over TFTP or HTTP (HTTP support depends on node firmware).
 
 ## Register the Servers


### PR DESCRIPTION
Fixes #1042