### PR TITLE
fix: break the link of metadata server to Talos machine config

### DIFF
--- a/app/sidero-controller-manager/controllers/server_controller.go
+++ b/app/sidero-controller-manager/controllers/server_controller.go
@@ -143,7 +143,7 @@ func (r *ServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 			// Talos installation was successful, so mark the server as PXE booted.
 			if conditions.IsTrue(serverBinding, infrav1.TalosInstalledCondition) {
-				conditions.MarkTrue(serverBinding, metalv1.ConditionPXEBooted)
+				conditions.MarkTrue(&s, metalv1.ConditionPXEBooted)
 			}
 		}
 	}

--- a/app/sidero-controller-manager/internal/metadata/fixture_test.go
+++ b/app/sidero-controller-manager/internal/metadata/fixture_test.go
@@ -1,0 +1,270 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package metadata_test
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	infrav1 "github.com/siderolabs/sidero/app/caps-controller-manager/api/v1alpha3"
+	metalv1 "github.com/siderolabs/sidero/app/sidero-controller-manager/api/v1alpha2"
+)
+
+func fixture() []client.Object {
+	var objects []client.Object
+
+	for _, fixture := range []func() []client.Object{
+		fixture1,
+		fixture2,
+		fixture3,
+		fixture4,
+		fixture5,
+	} {
+		objects = append(objects, fixture()...)
+	}
+
+	return objects
+}
+
+// fixture1 creates a server without config patches.
+func fixture1() []client.Object {
+	return fixtureSimple("0000-1111-2222", 1, `
+version: v1alpha1
+machine:
+  kubelet: {}
+`)
+}
+
+// fixture2 creates a server with Server-level config patches.
+func fixture2() []client.Object {
+	return []client.Object{
+		&infrav1.ServerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "1111-2222-3333",
+			},
+			Spec: infrav1.ServerBindingSpec{
+				MetalMachineRef: corev1.ObjectReference{
+					Name: "metal-machine-2",
+				},
+			},
+		},
+		&infrav1.MetalMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "metal-machine-2",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "cluster.x-k8s.io/v1beta1",
+						Kind:       "Machine",
+						Name:       "machine-2",
+					},
+				},
+			},
+			Spec: infrav1.MetalMachineSpec{},
+		},
+		&capiv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "machine-2",
+			},
+			Spec: capiv1.MachineSpec{
+				Bootstrap: capiv1.Bootstrap{
+					DataSecretName: pointer.String("bootstrap2"),
+				},
+			},
+		},
+		&metalv1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "1111-2222-3333",
+			},
+			Spec: metalv1.ServerSpec{
+				ConfigPatches: []metalv1.ConfigPatches{
+					{
+						Op:   "add",
+						Path: "/machine/network",
+						Value: v1.JSON{
+							Raw: []byte(`{"hostname":"example2"}`),
+						},
+					},
+				},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bootstrap2",
+			},
+			Data: map[string][]byte{
+				"value": []byte(`
+version: v1alpha1
+machine:
+  kubelet:
+    extraArgs:
+      foo: bar
+`),
+			},
+		},
+	}
+}
+
+// fixture3 creates a server with Server- & ServerClass-level config patches.
+func fixture3() []client.Object {
+	return []client.Object{
+		&infrav1.ServerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "2222-3333-4444",
+			},
+			Spec: infrav1.ServerBindingSpec{
+				MetalMachineRef: corev1.ObjectReference{
+					Name: "metal-machine-3",
+				},
+				ServerClassRef: &corev1.ObjectReference{
+					Name: "server-class-3",
+				},
+			},
+		},
+		&infrav1.MetalMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "metal-machine-3",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "cluster.x-k8s.io/v1beta1",
+						Kind:       "Machine",
+						Name:       "machine-3",
+					},
+				},
+			},
+			Spec: infrav1.MetalMachineSpec{},
+		},
+		&capiv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "machine-3",
+			},
+			Spec: capiv1.MachineSpec{
+				Bootstrap: capiv1.Bootstrap{
+					DataSecretName: pointer.String("bootstrap3"),
+				},
+			},
+		},
+		&metalv1.ServerClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "server-class-3",
+			},
+			Spec: metalv1.ServerClassSpec{
+				ConfigPatches: []metalv1.ConfigPatches{
+					{
+						Op:   "add",
+						Path: "/machine/network",
+						Value: v1.JSON{
+							Raw: []byte(`{"hostname":"invalid3"}`),
+						},
+					},
+				},
+			},
+		},
+		&metalv1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "2222-3333-4444",
+			},
+			Spec: metalv1.ServerSpec{
+				ConfigPatches: []metalv1.ConfigPatches{
+					{
+						Op:   "replace",
+						Path: "/machine/network/hostname",
+						Value: v1.JSON{
+							Raw: []byte(`"example3"`),
+						},
+					},
+				},
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bootstrap3",
+			},
+			Data: map[string][]byte{
+				"value": []byte(`
+version: v1alpha1
+machine:
+  kubelet:
+    extraArgs:
+      node-labels: foo=bar
+`),
+			},
+		},
+	}
+}
+
+// fixture4 creates a server machine config without machine.kubelet.
+func fixture4() []client.Object {
+	return fixtureSimple("4444-5555-6666", 4, `
+version: v1alpha1
+machine:
+  unsupported: {} # this is not supported by Talos, but should be passed through
+`)
+}
+
+// fixture5 creates a server machine config without machine.
+func fixture5() []client.Object {
+	return fixtureSimple("5555-6666-7777", 5, `
+version: v1alpha1
+cluster: {}
+`)
+}
+
+func fixtureSimple(uuid string, index int, config string) []client.Object {
+	return []client.Object{
+		&infrav1.ServerBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: uuid,
+			},
+			Spec: infrav1.ServerBindingSpec{
+				MetalMachineRef: corev1.ObjectReference{
+					Name: fmt.Sprintf("metal-machine-%d", index),
+				},
+			},
+		},
+		&infrav1.MetalMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("metal-machine-%d", index),
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "cluster.x-k8s.io/v1beta1",
+						Kind:       "Machine",
+						Name:       fmt.Sprintf("machine-%d", index),
+					},
+				},
+			},
+			Spec: infrav1.MetalMachineSpec{},
+		},
+		&capiv1.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("machine-%d", index),
+			},
+			Spec: capiv1.MachineSpec{
+				Bootstrap: capiv1.Bootstrap{
+					DataSecretName: pointer.String(fmt.Sprintf("bootstrap%d", index)),
+				},
+			},
+		},
+		&metalv1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: uuid,
+			},
+			Spec: metalv1.ServerSpec{},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("bootstrap%d", index),
+			},
+			Data: map[string][]byte{
+				"value": []byte(config),
+			},
+		},
+	}
+}

--- a/app/sidero-controller-manager/internal/metadata/metadata_server_test.go
+++ b/app/sidero-controller-manager/internal/metadata/metadata_server_test.go
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package metadata_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "github.com/siderolabs/sidero/app/caps-controller-manager/api/v1alpha3"
+	metalv1 "github.com/siderolabs/sidero/app/sidero-controller-manager/api/v1alpha2"
+	"github.com/siderolabs/sidero/app/sidero-controller-manager/internal/metadata"
+)
+
+func TestMetadataService(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, infrav1.AddToScheme(scheme))
+	require.NoError(t, metalv1.AddToScheme(scheme))
+	require.NoError(t, capiv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			fixture()...,
+		).
+		Build()
+
+	mux := http.NewServeMux()
+
+	metadata.RegisterServer(mux, fakeClient)
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	for _, test := range []struct {
+		name string
+		path string
+
+		expectedCode int
+		expectedBody string
+	}{
+		{
+			name: "invalid",
+			path: "/configdata",
+
+			expectedCode: http.StatusInternalServerError,
+			expectedBody: "received metadata request with empty uuid\n",
+		},
+		{
+			name: "not found",
+			path: "/configdata?uuid=xxx-yyy",
+
+			expectedCode: http.StatusNotFound,
+			expectedBody: "server is not allocated (missing serverbinding): serverbindings.infrastructure.cluster.x-k8s.io \"xxx-yyy\" not found\n",
+		},
+		{
+			name: "no patches",
+			path: "/configdata?uuid=0000-1111-2222",
+
+			expectedCode: http.StatusOK,
+			expectedBody: "machine:\n  kubelet:\n    extraArgs:\n      node-labels: metal.sidero.dev/uuid=0000-1111-2222\nversion: v1alpha1\n",
+		},
+		{
+			name: "server patch",
+			path: "/configdata?uuid=1111-2222-3333",
+
+			expectedCode: http.StatusOK,
+			expectedBody: "machine:\n  kubelet:\n    extraArgs:\n      foo: bar\n      node-labels: metal.sidero.dev/uuid=1111-2222-3333\n  network:\n    hostname: example2\nversion: v1alpha1\n",
+		},
+		{
+			name: "server and server class patch",
+			path: "/configdata?uuid=2222-3333-4444",
+
+			expectedCode: http.StatusOK,
+			expectedBody: "machine:\n  kubelet:\n    extraArgs:\n      node-labels: foo=bar,metal.sidero.dev/uuid=2222-3333-4444\n  network:\n    hostname: example3\nversion: v1alpha1\n",
+		},
+		{
+			name: "machine config without kubelet",
+			path: "/configdata?uuid=4444-5555-6666",
+
+			expectedCode: http.StatusOK,
+			expectedBody: "machine:\n  kubelet:\n    extraArgs:\n      node-labels: metal.sidero.dev/uuid=4444-5555-6666\n  unsupported: {}\nversion: v1alpha1\n",
+		},
+		{
+			name: "machine config without machine",
+			path: "/configdata?uuid=5555-6666-7777",
+
+			expectedCode: http.StatusOK,
+			expectedBody: "cluster: {}\nmachine:\n  kubelet:\n    extraArgs:\n      node-labels: metal.sidero.dev/uuid=5555-6666-7777\nversion: v1alpha1\n",
+		},
+	} {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp, err := http.Get(srv.URL + test.path) //nolint:noctx
+			require.NoError(t, err)
+
+			t.Cleanup(func() { resp.Body.Close() })
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedCode, resp.StatusCode)
+			assert.Equal(t, test.expectedBody, string(body))
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,6 @@ go 1.20
 replace github.com/pensando/goipmi v0.0.0-20200303170213-e858ec1cf0b5 => github.com/talos-systems/goipmi v0.0.0-20211214143420-35f956689e67
 
 require (
-	github.com/evanphx/json-patch v5.6.0+incompatible
-	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/go-cmp v0.5.9
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
@@ -35,6 +33,7 @@ require (
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20230215201556-9c5414ab4bde
 	google.golang.org/grpc v1.54.0
 	google.golang.org/protobuf v1.30.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.1
 	k8s.io/apiextensions-apiserver v0.26.1
 	k8s.io/apimachinery v0.26.1
@@ -56,8 +55,10 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
@@ -115,7 +116,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230330154414-c0448cd141ea // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/cluster-bootstrap v0.25.0 // indirect
 	k8s.io/component-base v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect

--- a/sfyra/pkg/bootstrap/cluster.go
+++ b/sfyra/pkg/bootstrap/cluster.go
@@ -137,6 +137,11 @@ func (cluster *Cluster) findExisting(ctx context.Context) error {
 		return err
 	}
 
+	cluster.workerIP, err = talosnet.NthIPInNetwork(cidr, 3)
+	if err != nil {
+		return err
+	}
+
 	cluster.access = access.NewAdapter(cluster.cluster, provision.WithTalosConfig(config))
 
 	return nil


### PR DESCRIPTION
Previous PR used Talos machinery to load the config, and then generate config patch to patch the config. This worked fine until Talos started validating loaded machine config for 'unknown fields'. This breaks this flow, as Omni Talos machinery version should be >= Talos version.

Rewriting the code to skip loading using Talos machinery, also handle cases of broken config without `machine` or `machine.kubelet` sections. These will probably be invalid anyways, but we let Talos report it instead of panic in Sidero.

Fixes #1076

Also use Talos machinery configpatcher to reduce code duplication.

And, last but not the least, add a unit-test for the metadata server, which covers all major code paths.

```
ok  	github.com/siderolabs/sidero/app/sidero-controller-manager/internal/metadata	0.022s	coverage: 72.8% of statements
```