### PR TITLE
fix: allow 'empty user' slots to be used in IPMI setup

### DIFF
--- a/app/sidero-controller-manager/cmd/agent/bmc.go
+++ b/app/sidero-controller-manager/cmd/agent/bmc.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"math/big"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/siderolabs/go-retry/retry"
@@ -128,7 +129,7 @@ func attemptBMCUserSetup(ctx context.Context, client api.AgentClient, s *smbios.
 			log.Printf("Sidero user already present in slot %d. We'll claim it as our very own.\n", i)
 
 			break
-		} else if userRes.Username == "" && sideroUserID == 0 {
+		} else if (userRes.Username == "" || strings.TrimSpace(userRes.Username) == "(Empty User)") && sideroUserID == 0 {
 			// If this is the first empty user that's not the UID 1 (which we skip),
 			// we'll take this spot for sidero user
 			log.Printf("Found empty user slot %d. Noting as a possible place for sidero user.\n", i)

--- a/app/sidero-controller-manager/cmd/agent/main.go
+++ b/app/sidero-controller-manager/cmd/agent/main.go
@@ -84,7 +84,7 @@ func mainFunc() error {
 		log.Println("failed to discover IPs")
 	} else {
 		if err = reconcileIPs(ctx, client, s, ips); err != nil {
-			shutdown(err)
+			return err
 		}
 
 		log.Printf("Reconciled IPs")
@@ -93,7 +93,7 @@ func mainFunc() error {
 	if createResp.GetWipe() {
 		disks, err := disk.List()
 		if err != nil {
-			shutdown(err)
+			return err
 		}
 
 		var (
@@ -176,11 +176,11 @@ func mainFunc() error {
 		}
 
 		if err := eg.Wait(); err != nil {
-			shutdown(err)
+			return err
 		}
 
 		if err := wipe(ctx, client, s); err != nil {
-			shutdown(err)
+			return err
 		}
 
 		log.Println("Wipe complete")


### PR DESCRIPTION
Fixes #1078