### PR TITLE
fix: surround IPv6 addresses with brackets

### DIFF
--- a/app/sidero-controller-manager/cmd/siderolink-manager/main.go
+++ b/app/sidero-controller-manager/cmd/siderolink-manager/main.go
@@ -176,7 +176,11 @@ func run() error {
 func getIPForHost(host string) (string, error) {
 	parsedIP, err := netip.ParseAddr(host)
 	if err == nil {
-		return parsedIP.String(), nil
+		if parsedIP.Is6() {
+			return "[" + parsedIP.String() + "]", nil
+		} else {
+			return parsedIP.String(), nil
+		}
 	}
 
 	resolvedIPs, err := net.LookupIP(host)
@@ -188,5 +192,10 @@ func getIPForHost(host string) (string, error) {
 		return "", fmt.Errorf("no IPs found for %s", host)
 	}
 
-	return resolvedIPs[0].String(), nil
+	ip := resolvedIPs[0]
+	if ip.To4() == nil {
+		return "[" + ip.String() + "]", nil
+	} else {
+		return ip.String(), nil
+	}
 }


### PR DESCRIPTION
The host IP address is passed to `netip.ParseAddrPort`, which returns an error if IPv6 addresses are not surrounded in brackets. This happens when the Kubernetes node has an IPv6 address. Errors I saw in my logs:
```
❯ kubectl logs -n sidero-system sidero-controller-manager-64788bbf65-w42f7 siderolink 
I0428 12:29:44.434812       1 request.go:601] Waited for 1.04738863s due to client-side throttling, not priority and fairness, request: GET:https://[2a02:****:****:1000::11:1]:443/apis/cilium.io/v2?timeout=32s
error: invalid Wireguard endpoint: invalid ip:port "2a02:****:****:0:d250:99ff:fefa:a836:51821", IPv6 addresses must be surrounded by square brackets
```