### PR TITLE
docs: update taint names `master`=>`control-plane`

### DIFF
--- a/website/content/v0.4/Guides/bootstrapping.md
+++ b/website/content/v0.4/Guides/bootstrapping.md
@@ -138,7 +138,7 @@ You should then set your `KUBECONFIG` environment variable to the path of this f
 Because this is a single node cluster, we need to remove the "NoSchedule" taint on the node to make sure non-controlplane components can be scheduled.
 
 ```bash
-kubectl taint node talos-default-master-1 node-role.kubernetes.io/master:NoSchedule-
+kubectl taint node talos-default-master-1 node-role.kubernetes.io/control-plane::NoSchedule-
 ```
 
 ## Install Sidero

--- a/website/content/v0.5/Guides/bootstrapping.md
+++ b/website/content/v0.5/Guides/bootstrapping.md
@@ -138,7 +138,7 @@ You should then set your `KUBECONFIG` environment variable to the path of this f
 Because this is a single node cluster, we need to remove the "NoSchedule" taint on the node to make sure non-controlplane components can be scheduled.
 
 ```bash
-kubectl taint node talos-default-master-1 node-role.kubernetes.io/master:NoSchedule-
+kubectl taint node talos-default-master-1 node-role.kubernetes.io/control-plane::NoSchedule-
 ```
 
 ## Install Sidero

--- a/website/content/v0.6/Guides/bootstrapping.md
+++ b/website/content/v0.6/Guides/bootstrapping.md
@@ -138,7 +138,7 @@ You should then set your `KUBECONFIG` environment variable to the path of this f
 Because this is a single node cluster, we need to remove the "NoSchedule" taint on the node to make sure non-controlplane components can be scheduled.
 
 ```bash
-kubectl taint node talos-default-master-1 node-role.kubernetes.io/master:NoSchedule-
+kubectl taint node talos-default-master-1 node-role.kubernetes.io/control-plane::NoSchedule-
 ```
 
 ## Install Sidero


### PR DESCRIPTION
https://github.com/kubernetes/enhancements/blob/35befff0ad33187b2c93141d5fe1513a1b4a39a1/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint/README.md#summary