### PR TITLE
docs: remove excess bash continuation backslashes

### DIFF
--- a/website/content/v0.4/Getting Started/prereq-cli-tools.md
+++ b/website/content/v0.4/Getting Started/prereq-cli-tools.md
@@ -39,7 +39,7 @@ The main article for installing `clusterctl` can be found
 
 ```bash
 sudo curl -Lo /usr/local/bin/clusterctl \
-  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64" \
+  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v0.4.7/clusterctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
 sudo chmod +x /usr/local/bin/clusterctl
 ```
 

--- a/website/content/v0.5/Getting Started/prereq-cli-tools.md
+++ b/website/content/v0.5/Getting Started/prereq-cli-tools.md
@@ -39,7 +39,7 @@ The main article for installing `clusterctl` can be found
 
 ```bash
 sudo curl -Lo /usr/local/bin/clusterctl \
-  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.1/clusterctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64" \
+  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.1/clusterctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
 sudo chmod +x /usr/local/bin/clusterctl
 ```
 

--- a/website/content/v0.6/Getting Started/prereq-cli-tools.md
+++ b/website/content/v0.6/Getting Started/prereq-cli-tools.md
@@ -39,7 +39,7 @@ The main article for installing `clusterctl` can be found
 
 ```bash
 sudo curl -Lo /usr/local/bin/clusterctl \
-  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/clusterctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64" \
+  "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.5.0/clusterctl-$(uname -s | tr '[:upper:]' '[:lower:]')-amd64"
 sudo chmod +x /usr/local/bin/clusterctl
 ```
 


### PR DESCRIPTION
`sudo` begins a new command, so the preceding line must not end in `\`.