### PR TITLE
fix: don't send option 60 in DHCP responses

### DIFF
--- a/app/sidero-controller-manager/internal/dhcp/dhcp_server.go
+++ b/app/sidero-controller-manager/internal/dhcp/dhcp_server.go
@@ -148,7 +148,6 @@ func offerDHCP(req *dhcpv4.DHCPv4, apiEndpoint string, apiPort int, fwtype Firmw
 	modifiers := []dhcpv4.Modifier{
 		dhcpv4.WithServerIP(serverIP),
 		dhcpv4.WithOptionCopied(req, dhcpv4.OptionClientMachineIdentifier),
-		dhcpv4.WithOptionCopied(req, dhcpv4.OptionClassIdentifier),
 	}
 
 	resp, err := dhcpv4.NewReplyFromRequest(req,
@@ -156,10 +155,6 @@ func offerDHCP(req *dhcpv4.DHCPv4, apiEndpoint string, apiPort int, fwtype Firmw
 	)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.GetOneOption(dhcpv4.OptionClassIdentifier) == nil {
-		resp.UpdateOption(dhcpv4.OptClassIdentifier("PXEClient"))
 	}
 
 	switch fwtype {


### PR DESCRIPTION
This seems to trigger the behavior to look for proxyDHCP on port 4011, see e.g.
https://www.prajwaldesai.com/pxe-e55-proxydhcp-did-not-reply-to-request-on-port-4011/.

See #1212