### PR TITLE
docs: Disk is double

### DIFF
--- a/website/content/v0.6/Guides/sidero-on-rpi4.md
+++ b/website/content/v0.6/Guides/sidero-on-rpi4.md
@@ -30,7 +30,7 @@ export SIDERO_ENDPOINT=192.168.x.x
 Generate Talos machine configuration for a single-node cluster:
 
 ```bash
-talosctl gen config --config-patch='[{"op": "add", "path": "/cluster/allowSchedulingOnControlPlanes", "value": true},{"op": "replace", "path": "/machine/install/disk", "value": "/dev/mmcblk0"}]' rpi4-sidero https://${SIDERO_ENDPOINT}:6443/
+talosctl gen config --config-patch='[{"op": "add", "path": "/cluster/allowSchedulingOnControlPlanes", "value": true},{"op": "replace", "path": "/machine/install", "value": "/dev/mmcblk0"}]' rpi4-sidero https://${SIDERO_ENDPOINT}:6443/
 ```
 
 Submit the generated configuration to Talos:

--- a/website/content/v0.6/Resource Configuration/metadata.md
+++ b/website/content/v0.6/Resource Configuration/metadata.md
@@ -99,7 +99,7 @@ metadata:
 spec:
   configPatches:
   - op: replace
-    path: /machine/install/disk
+    path: /machine/install
     value: /dev/nvme0n1
   - op: add
     path: /machine/install/extraKernelArgs
@@ -135,7 +135,7 @@ metadata:
 spec:
   configPatches:
   - op: replace
-    path: /machine/install/disk
+    path: /machine/install
     value: /dev/nvme1n1
   - op: add
     path: /machine/install/extraKernelArgs

--- a/website/content/v0.6/Resource Configuration/serverclasses.md
+++ b/website/content/v0.6/Resource Configuration/serverclasses.md
@@ -84,7 +84,7 @@ kind: ServerClass
 spec:
   configPatches:
     - op: replace
-      path: /machine/install/disk
+      path: /machine/install
       value: /dev/sda
 ```
 

--- a/website/content/v0.6/Resource Configuration/servers.md
+++ b/website/content/v0.6/Resource Configuration/servers.md
@@ -102,7 +102,7 @@ spec:
   accepted: false
   configPatches:
     - op: replace
-      path: /machine/install/disk
+      path: /machine/install
       value: /dev/sda
 ```
 
@@ -115,7 +115,7 @@ kind: ServerClass
 spec:
   configPatches:
     - op: replace
-      path: /machine/install/disk
+      path: /machine/install
       value: /dev/sda
 ```
 


### PR DESCRIPTION
I think that https://www.sidero.dev/v0.6/resource-configuration/servers/#installation-disk is wrong:
```
spec:
  accepted: false
  configPatches:
    - op: replace
      path: /machine/install/disk
      value: /dev/sda
```

This leads to `machine.install.disk.disk: value`, but it needs `machine.install.disk: value`

How i found that? https://taloscommunity.slack.com/archives/CMARMBC4E/p1697122617304659

I changed it (as it is already writen in https://www.sidero.dev/v0.6/guides/patching/) and the error went away.
I found some more similar code bits and fixed them too. 