### PR TITLE
docs: fix website redirect to latest version

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -2,8 +2,8 @@
 ## There's a way to do it, but I couldn't get it to work quickly.
 ## See https://dev.to/faraixyz/setting-a-custom-output-format-in-hugo-for-netlify-or-gitlab-page-s-redirects-file-4dcf
 ## for what I'm talking about
-/docs     /v0.5  302
+/docs     /v0.6  302
 /docs/*  /:splat 302
 
-/latest     /v0.5  302
-/latest/*   /v0.5/:splat  302
+/latest     /v0.6  302
+/latest/*   /v0.6/:splat  302


### PR DESCRIPTION
The website currently redirects to 0.5 instead of 0.6