### PR TITLE
fix: set a default controller runtime log

### DIFF
--- a/app/caps-controller-manager/main.go
+++ b/app/caps-controller-manager/main.go
@@ -17,6 +17,7 @@ import (
 	cgrecord "k8s.io/client-go/tools/record"
 	"k8s.io/component-base/logs"
 	logsv1 "k8s.io/component-base/logs/api/v1"
+	"k8s.io/klog/v2"
 	capiv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util/flags"
@@ -88,6 +89,9 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+
+	// klog.Background will automatically use the right logger.
+	ctrl.SetLogger(klog.Background())
 
 	diagnosticsOpts := flags.GetDiagnosticsOptions(diagnosticsOptions)
 

--- a/app/sidero-controller-manager/main.go
+++ b/app/sidero-controller-manager/main.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/logs"
 	logsv1 "k8s.io/component-base/logs/api/v1"
+	"k8s.io/klog/v2"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/flags"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -136,6 +137,9 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
+
+	// klog.Background will automatically use the right logger.
+	ctrl.SetLogger(klog.Background())
 
 	diagnosticsOpts := flags.GetDiagnosticsOptions(diagnosticsOptions)
 


### PR DESCRIPTION
See https://github.com/siderolabs/cluster-api-bootstrap-provider-talos/issues/185