### PR TITLE
docs: add Omni bare metal infra provider link to maintenance warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@
 <!-- textlint-disable -->
 > [!CAUTION]
 > Sidero Labs is no longer actively developing Sidero Metal.
-> For an alternative, please see [Omni](https://github.com/siderolabs/omni.git).
+>
+> For an alternative, please see [Omni](https://github.com/siderolabs/omni.git)
+> and the [Bare-Metal Infrastructure Provider](https://omni.siderolabs.com/tutorials/setting-up-the-bare-metal-infrastructure-provider).
+>
 > Unless you have an existing support contract covering Sidero Metal, all support will be provided by the community (including questions in our Slack workspace).
 <!-- textlint-enable -->
 

--- a/website/content/_index.html
+++ b/website/content/_index.html
@@ -17,8 +17,9 @@ title = "Sidero Metal"
 
 <section class="">
   <div class="container">
-    <p class="text-center my-5 h5" style="color:red">Sidero Labs is no longer actively developing Sidero Metal.
-      For an alternative, please see <a href="https://github.com/siderolabs/omni.git">Omni</a>.
+    <p class="text-center my-5 h5" style="color:red">Sidero Labs is no longer actively developing Sidero Metal.<br/>
+      For an alternative, please see <a href="https://github.com/siderolabs/omni.git">Omni</a>
+      and the <a href="https://omni.siderolabs.com/tutorials/setting-up-the-bare-metal-infrastructure-provider">Bare-Metal Infrastructure Provider</a>.<br/>
       Unless you have an existing support contract covering Sidero Metal, all support will be provided by the community (including questions in our Slack workspace).
     </p>
 

--- a/website/content/v0.6/_index.md
+++ b/website/content/v0.6/_index.md
@@ -9,8 +9,9 @@ menu: main
 
 Welcome to the Sidero Metal documentation.
 
-> :warning: Sidero Labs is no longer actively developing Sidero Metal.
-  For an alternative, please see <a href="https://github.com/siderolabs/omni.git">Omni</a>.
+> :warning: Sidero Labs is no longer actively developing Sidero Metal.<br/>
+  For an alternative, please see <a href="https://github.com/siderolabs/omni.git">Omni</a>
+  and the <a href="https://omni.siderolabs.com/tutorials/setting-up-the-bare-metal-infrastructure-provider">Bare-Metal Infrastructure Provider</a>.<br/>
   Unless you have an existing support contract covering Sidero Metal, all support will be provided by the community (including questions in our Slack workspace).
 
 ## Community


### PR DESCRIPTION
Refer to the bare metal infra provider, as it is the spiritual successor of Sidero Metal.