### PR TITLE
fix: multi doc machine config generation

### DIFF
--- a/app/sidero-controller-manager/internal/metadata/fixture_test.go
+++ b/app/sidero-controller-manager/internal/metadata/fixture_test.go
@@ -206,7 +206,6 @@ func fixture4() []client.Object {
 	return fixtureSimple("4444-5555-6666", 4, `
 version: v1alpha1
 machine:
-  unsupported: {} # this is not supported by Talos, but should be passed through
 `)
 }
 
@@ -273,7 +272,15 @@ func fixture6() []client.Object {
 				Name: "6666-7777-8888",
 			},
 			Spec: metalv1.ServerSpec{
-				StrategicPatches: []string{newConfigPatch},
+				StrategicPatches: []string{
+					newConfigPatch,
+					`
+apiVersion: v1alpha1
+kind: ExtensionServiceConfig
+name: frr
+environment:
+- TESTKEY=TESTVALUE`,
+				},
 			},
 		},
 		&corev1.Secret{

--- a/app/sidero-controller-manager/internal/metadata/metadata_server_test.go
+++ b/app/sidero-controller-manager/internal/metadata/metadata_server_test.go
@@ -92,7 +92,7 @@ func TestMetadataService(t *testing.T) {
 			path: "/configdata?uuid=4444-5555-6666",
 
 			expectedCode: http.StatusOK,
-			expectedBody: "machine:\n  kubelet:\n    extraArgs:\n      node-labels: metal.sidero.dev/uuid=4444-5555-6666\n  unsupported: {}\nversion: v1alpha1\n",
+			expectedBody: "machine:\n  kubelet:\n    extraArgs:\n      node-labels: metal.sidero.dev/uuid=4444-5555-6666\nversion: v1alpha1\n",
 		},
 		{
 			name: "machine config without machine",
@@ -106,7 +106,7 @@ func TestMetadataService(t *testing.T) {
 			path: "/configdata?uuid=6666-7777-8888",
 
 			expectedCode: http.StatusOK,
-			expectedBody: "cluster: null\nmachine:\n  certSANs: []\n  kubelet:\n    extraArgs:\n      node-labels: foo=bar,metal.sidero.dev/uuid=6666-7777-8888\n  network:\n    hostname: example6\n  token: \"\"\n  type: \"\"\nversion: v1alpha1\n",
+			expectedBody: "version: v1alpha1\nmachine:\n    type: \"\"\n    token: \"\"\n    certSANs: []\n    kubelet:\n        extraArgs:\n            node-labels: foo=bar,metal.sidero.dev/uuid=6666-7777-8888\n    network:\n        hostname: example6\ncluster: null\n---\napiVersion: v1alpha1\nkind: ExtensionServiceConfig\nname: frr\nenvironment:\n    - TESTKEY=TESTVALUE\n",
 		},
 	} {
 		test := test


### PR DESCRIPTION
The very last step in the machine config generation is to apply a specific node label to match the Kubernetes node back to the Machine.

This step was using legacy JSON patches which rendered impossible to use multi-doc machine config.

Rebuild to use strategic patch instead, this changes formatting of the config in the tests, but not in real production.

Also this means that Sidero is locked to the Talos version it was built for (it won't support newer Talos machine configs), but that has already been the case with strategic patches.