### PR TITLE
fix: exclude control plane endpoint from MetalMachine addresses

### DIFF
--- a/app/caps-controller-manager/controllers/metalmachine_controller.go
+++ b/app/caps-controller-manager/controllers/metalmachine_controller.go
@@ -211,6 +211,11 @@ func (r *MetalMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 		addresses := make([]capiv1.MachineAddress, 0, len(serverBinding.Spec.Addresses))
 		for _, addr := range serverBinding.Spec.Addresses {
+			// skip shared control plane endpoint unless it's the only address (single-node)
+			if addr == cluster.Spec.ControlPlaneEndpoint.Host && len(serverBinding.Spec.Addresses) > 1 {
+				continue
+			}
+
 			addresses = append(addresses, capiv1.MachineAddress{
 				Type:    capiv1.MachineInternalIP,
 				Address: addr,


### PR DESCRIPTION
When Talos reports node addresses, it includes the shared control plane endpoint (e.g. a VIP). Sidero correctly stores these in `ServerBinding.Spec.Addresses`. But when the MetalMachine controller copies them into `MetalMachine.Status.Addresses`, the shared endpoint propagates to `Machine.Status.Addresses`, where CACPPT treats it as a per-machine Talos API endpoint. This breaks scale-down operations.

This PR filters the control plane endpoint at the CAPI boundary in `metalmachine_controller.go`, where the `Cluster` object is already in scope. `ServerBinding` retains the full address list.

Safe when `ControlPlaneEndpoint.Host` is empty — comparison against `""` matches nothing, all addresses pass through.

Ref: siderolabs/cluster-api-control-plane-provider-talos#242

🤖 Co-authored with AI